### PR TITLE
Reorder project list on homepage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -76,14 +76,6 @@
         <section>
             <h2 class="text-2xl font-semibold mb-4">Projects</h2>
             <div class="space-y-6">
-                <a href="https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender" class="project-card">
-                    <h3 class="font-semibold text-blue-600">Defender Remake on Atari ST</h3>
-                    <p class="text-gray-700">Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.</p>
-                </a>
-                <a href="https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell" class="project-card">
-                    <h3 class="font-semibold text-blue-600">Linux Shell Development</h3>
-                    <p class="text-gray-700">Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.</p>
-                </a>
                 <a href="https://github.com/axyl-casc/Anscombes_Research?tab=readme-ov-file#anscombes-quartet-research-project" class="project-card">
                     <h3 class="font-semibold text-blue-600">Anscombe's Quartet Research</h3>
                     <p class="text-gray-700">Created a program to replicate Anscombe's Quartet, emphasizing the importance of visual data analysis.</p>
@@ -95,6 +87,14 @@
                 <a href="https://zxnashx.itch.io/beginner-go-game" class="project-card">
                     <h3 class="font-semibold text-blue-600">Beginner GO AI Game</h3>
                     <p class="text-gray-700">A GO playing interface designed to teach beginners how to play the game of GO. </p>
+                </a>
+                <a href="https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender" class="project-card">
+                    <h3 class="font-semibold text-blue-600">Defender Remake on Atari ST</h3>
+                    <p class="text-gray-700">Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.</p>
+                </a>
+                <a href="https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell" class="project-card">
+                    <h3 class="font-semibold text-blue-600">Linux Shell Development</h3>
+                    <p class="text-gray-700">Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.</p>
                 </a>
                 <a href="./other_projects.html" class="project-card">
                     <h3 class="font-semibold text-blue-600">Other Projects</h3>
@@ -131,4 +131,3 @@
     <script src="./js/main.js"></script>
 </body>
 </html>
-


### PR DESCRIPTION
### Motivation
- Reorder the displayed projects so the three highlighted items appear first for better prominence and user focus.
- Specifically promote Anscombe's Quartet, Infinite Mind Games (Wiki), and the Beginner GO project to the top of the list.

### Description
- Updated `public/index.html` to reorder the project cards so Anscombe's Quartet, Infinite Mind Games, and Beginner GO appear before the other projects.
- Moved the Defender Remake and Linux Shell cards later in the list and kept the `Other Projects` link at the end.
- No other source files or assets were modified.

### Testing
- Launched a local server with `python -m http.server 8000` and verified the site served successfully.
- Captured a screenshot of the updated homepage using a Playwright script which produced `artifacts/projects-order.png` successfully.
- No unit or integration test suites were run for this static HTML change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960a6d3d9f8832b96d624ff3745ff66)