### PR TITLE
Add GoGuesser to Other Projects page

### DIFF
--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -49,6 +49,12 @@
                     A daily to-do list app I use for language learning and tracking whatever currently interests me.
                 </p>
             </a>
+            <a href="https://goguesser.onrender.com/" class="project-card">
+                <h3 class="font-semibold text-blue-600">GoGuesser</h3>
+                <p class="text-gray-700">
+                    Guess the next best move in a Go game.
+                </p>
+            </a>
         </div>
     </main>
 
@@ -58,4 +64,3 @@
     </footer>
 </body>
 </html>
-


### PR DESCRIPTION
### Motivation

- Surface the GoGuesser web app as part of the portfolio so visitors can open and try the app.
- Keep the Other Projects page updated with notable personal projects.

### Description

- Add a new project card anchor to `public/other_projects.html` linking to `https://goguesser.onrender.com/`.
- Include the project title `GoGuesser` and a short description "Guess the next best move in a Go game.".
- This is a static HTML-only change and does not modify styling or scripts.

### Testing

- Served the `public` folder with `python -m http.server 8000` and loaded `/other_projects.html` using a Playwright script which completed successfully.
- The page screenshot was captured to `artifacts/other-projects.png` confirming the new card renders as expected.
- No unit tests exist for this static content change and none were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69658f407d44832bb13de31235e8d5a3)