### PR TITLE
Fix footer positioning on other projects page

### DIFF
--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -23,7 +23,7 @@
     </header>
 
     <!-- Project Cards -->
-    <main>
+    <main class="flex-1">
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             <a href="https://axyl-casc.github.io/WebDevelopment/Assignment%202/" class="project-card">
                 <h3 class="font-semibold text-blue-600">F1 - Race Dashboard</h3>
@@ -59,7 +59,7 @@
     </main>
 
     <!-- Footer -->
-    <footer class="absolute inset-x-0 bottom-0">
+    <footer class="mt-auto">
         <p>&copy; 2025 Axyl Carefoot-Schulz</p>
     </footer>
 </body>


### PR DESCRIPTION
### Motivation
- Make the footer sit at the bottom of the viewport on the Other Projects page by letting the main content grow within the page's flex layout.

### Description
- Add `flex-1` to the `<main>` element and replace the footer's `absolute inset-x-0 bottom-0` classes with `mt-auto` in `public/other_projects.html` so the footer participates in the page flex layout.

### Testing
- Started a local server with `python -m http.server 4173` and ran a Playwright script to capture `http://127.0.0.1:4173/public/other_projects.html`, which produced `artifacts/other-projects-footer.png` (page rendered) but the stylesheet `./styles/tw.css` returned a 404 during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972766db39c832b84b9e323163e5f8b)