### PR TITLE
Add Dice Simulator link to other projects page

### DIFF
--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -55,6 +55,12 @@
                     Guess the next best move in a Go game.
                 </p>
             </a>
+            <a href="https://axyl-casc.github.io/Dice-Simulator/" class="project-card">
+                <h3 class="font-semibold text-blue-600">Dice Simulator</h3>
+                <p class="text-gray-700">
+                    Generate probability distribution tables from custom sets of dice.
+                </p>
+            </a>
         </div>
     </main>
 


### PR DESCRIPTION
### Motivation
- Add the Dice Simulator project to the site so visitors can discover the tool that generates probability distribution tables for custom dice sets.

### Description
- Updated `public/other_projects.html` to add a new project card linking to `https://axyl-casc.github.io/Dice-Simulator/` with a short description explaining it generates probability distribution tables from custom sets of dice.

### Testing
- Verified the HTML change by inspecting `public/other_projects.html` with `nl`/`git status` and attempted to serve the site with `python3 -m http.server` and capture a screenshot with Playwright, where the file inspection succeeded but the Playwright browser crashed (SIGSEGV) so no screenshot was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d05d60540832bbaa47e96c542f88f)