### PR TITLE
Add Fancy Pants Outfitters (React demo) to homepage projects

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -82,6 +82,10 @@
                     <h3 class="font-semibold text-blue-600">Beginner GO AI Game</h3>
                     <p class="text-gray-700">A GO playing interface designed to teach beginners how to play the game of GO. </p>
                 </a>
+                <a href="https://acare3.github.io/4513_2_website/" class="project-card">
+                    <h3 class="font-semibold text-blue-600">Fancy Pants Outfitters (React Demo)</h3>
+                    <p class="text-gray-700">A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.</p>
+                </a>
                 <a href="https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender" class="project-card">
                     <h3 class="font-semibold text-blue-600">Defender Remake on Atari ST</h3>
                     <p class="text-gray-700">Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.</p>


### PR DESCRIPTION
### Motivation
- Surface a React storefront demo in the main Projects section so visitors can view a polished example of a modern frontend demo and curated product UX.

### Description
- Added a new project card to `public/index.html` linking to `https://acare3.github.io/4513_2_website/` with the title "Fancy Pants Outfitters (React Demo)" and a concise summary matching existing project entries.
- Committed the change to the repository after updating the homepage HTML.

### Testing
- Ran `npm run build` to rebuild site assets and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb59353f8c832bb04295bdbfb839ce)