### PR TITLE
Remove F1 dashboard card from other projects page

### DIFF
--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -25,12 +25,6 @@
     <!-- Project Cards -->
     <main class="flex-1">
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
-            <a href="https://axyl-casc.github.io/WebDevelopment/Assignment%202/" class="project-card">
-                <h3 class="font-semibold text-blue-600">F1 - Race Dashboard</h3>
-                <p class="text-gray-700">
-                    View different races by season. Save your favourite constructors and drivers as well. 
-                </p>
-            </a>
             <a href="https://axyl-casc.github.io/Scheduler-Designer/" class="project-card">
                 <h3 class="font-semibold text-blue-600">CPU Scheduler</h3>
                 <p class="text-gray-700">


### PR DESCRIPTION
### Motivation
- Remove the `F1 - Race Dashboard` card so it no longer appears on the "Other Projects" listing in `public/other_projects.html`.

### Description
- Deleted the HTML block for the `F1 - Race Dashboard` project card from `public/other_projects.html`, leaving all other project cards and page structure unchanged.

### Testing
- Ran `rg -n "F1 - Race Dashboard|WebDevelopment/Assignment%202" public/other_projects.html` and `git status --short`, both of which succeeded and show the change was applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5b104fa44832b8417583c6bf7d3c5)