### PR TITLE
Add tag badges and update project titles on public pages

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -69,17 +69,52 @@
         <!-- Projects -->
         <section>
             <h2 class="text-2xl font-semibold mb-4">Projects</h2>
+            <div class="mb-4">
+                <p class="text-gray-700 mb-2"><strong>Tags:</strong></p>
+                <div class="flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-red-600 border border-red-500 rounded-full bg-red-50">Python</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-orange-600 border border-orange-500 rounded-full bg-orange-50">data analysis</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">javascript</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-yellow-700 border border-yellow-500 rounded-full bg-yellow-50">java</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-lime-700 border border-lime-500 rounded-full bg-lime-50">leadership</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-green-600 border border-green-500 rounded-full bg-green-50">AI</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-emerald-600 border border-emerald-500 rounded-full bg-emerald-50">nodejs</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-teal-600 border border-teal-500 rounded-full bg-teal-50">tailwind</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-cyan-600 border border-cyan-500 rounded-full bg-cyan-50">C</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-sky-600 border border-sky-500 rounded-full bg-sky-50">assembly</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-blue-600 border border-blue-500 rounded-full bg-blue-50">linux</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-indigo-600 border border-indigo-500 rounded-full bg-indigo-50">Operating Systems</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-violet-600 border border-violet-500 rounded-full bg-violet-50">Haskell</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-fuchsia-600 border border-fuchsia-500 rounded-full bg-fuchsia-50">auto deployment</span>
+                </div>
+            </div>
             <div class="space-y-6">
                 <a href="https://github.com/axyl-casc/Anscombes_Research?tab=readme-ov-file#anscombes-quartet-research-project" class="project-card">
-                    <h3 class="font-semibold text-blue-600">Anscombe's Quartet Research</h3>
+                    <h3 class="font-semibold text-blue-600">Anscombes</h3>
+                    <div class="mt-1 flex flex-wrap gap-2">
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-red-600 border border-red-500 rounded-full bg-red-50">Python</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-orange-600 border border-orange-500 rounded-full bg-orange-50">data analysis</span>
+                    </div>
                     <p class="text-gray-700">Created a program to replicate Anscombe's Quartet, emphasizing the importance of visual data analysis.</p>
                 </a>
                 <a href="https://infinite-mind-pictures-inc.github.io/Infinite-Mind-Wiki/" class="project-card">
-                  <h3 class="font-semibold text-blue-600">Infinite Mind Games – Wiki Docs</h3>
+                  <h3 class="font-semibold text-blue-600">Wiki docs</h3>
+                  <div class="mt-1 flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">javascript</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-yellow-700 border border-yellow-500 rounded-full bg-yellow-50">java</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-lime-700 border border-lime-500 rounded-full bg-lime-50">leadership</span>
+                  </div>
                   <p class="text-gray-700">An interactive documentation site built with Quartz, featuring guides, learning modules, and development notes for Infinite Mind Games projects.</p>
                 </a>
                 <a href="https://zxnashx.itch.io/beginner-go-game" class="project-card">
                     <h3 class="font-semibold text-blue-600">Beginner GO AI Game</h3>
+                    <div class="mt-1 flex flex-wrap gap-2">
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-green-600 border border-green-500 rounded-full bg-green-50">AI</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-red-600 border border-red-500 rounded-full bg-red-50">python</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">javascript</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-emerald-600 border border-emerald-500 rounded-full bg-emerald-50">nodejs</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-teal-600 border border-teal-500 rounded-full bg-teal-50">tailwind</span>
+                    </div>
                     <p class="text-gray-700">A GO playing interface designed to teach beginners how to play the game of GO. </p>
                 </a>
                 <a href="https://acare3.github.io/4513_2_website/" class="project-card">
@@ -87,11 +122,19 @@
                     <p class="text-gray-700">A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.</p>
                 </a>
                 <a href="https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender" class="project-card">
-                    <h3 class="font-semibold text-blue-600">Defender Remake on Atari ST</h3>
+                    <h3 class="font-semibold text-blue-600">Defender remake</h3>
+                    <div class="mt-1 flex flex-wrap gap-2">
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-cyan-600 border border-cyan-500 rounded-full bg-cyan-50">C</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-sky-600 border border-sky-500 rounded-full bg-sky-50">assembly</span>
+                    </div>
                     <p class="text-gray-700">Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.</p>
                 </a>
                 <a href="https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell" class="project-card">
-                    <h3 class="font-semibold text-blue-600">Linux Shell Development</h3>
+                    <h3 class="font-semibold text-blue-600">Linux shell development</h3>
+                    <div class="mt-1 flex flex-wrap gap-2">
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-cyan-600 border border-cyan-500 rounded-full bg-cyan-50">C</span>
+                        <span class="inline-block px-3 py-1 text-sm font-semibold text-blue-600 border border-blue-500 rounded-full bg-blue-50">linux</span>
+                    </div>
                     <p class="text-gray-700">Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.</p>
                 </a>
                 <a href="./other_projects.html" class="project-card">

--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -27,30 +27,48 @@
         <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
             <a href="https://axyl-casc.github.io/Scheduler-Designer/" class="project-card">
                 <h3 class="font-semibold text-blue-600">CPU Scheduler</h3>
+                <div class="mt-1 flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-indigo-600 border border-indigo-500 rounded-full bg-indigo-50">Operating Systems</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">Javascript</span>
+                </div>
                 <p class="text-gray-700">
                     Run different CPU scheduling algorithms interactively and view the results afterwards.
                 </p>
             </a>
             <a href="https://github.com/axyl-casc/AirplaneGraphProject?tab=readme-ov-file#readme" class="project-card">
-                <h3 class="font-semibold text-blue-600">Airplane Package Scheduler</h3>
+                <h3 class="font-semibold text-blue-600">Airplace Package Scheduler</h3>
+                <div class="mt-1 flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-violet-600 border border-violet-500 rounded-full bg-violet-50">Haskell</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">javascript</span>
+                </div>
                 <p class="text-gray-700">
                     Effectively calculates possible routes for airplanes to deliver packages with a version made in Javascript and Haskell.
                 </p>
             </a>
             <a href="https://axyl-casc.github.io/TrainingGame/" class="project-card">
-                <h3 class="font-semibold text-blue-600">Daily Training Game</h3>
+                <h3 class="font-semibold text-blue-600">Daily Training game</h3>
+                <div class="mt-1 flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">Javascript</span>
+                </div>
                 <p class="text-gray-700">
                     A daily to-do list app I use for language learning and tracking whatever currently interests me.
                 </p>
             </a>
             <a href="https://goguesser.onrender.com/" class="project-card">
                 <h3 class="font-semibold text-blue-600">GoGuesser</h3>
+                <div class="mt-1 flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">Javascript</span>
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-fuchsia-600 border border-fuchsia-500 rounded-full bg-fuchsia-50">auto deployment</span>
+                </div>
                 <p class="text-gray-700">
                     Guess the next best move in a Go game.
                 </p>
             </a>
             <a href="https://axyl-casc.github.io/Dice-Simulator/" class="project-card">
-                <h3 class="font-semibold text-blue-600">Dice Simulator</h3>
+                <h3 class="font-semibold text-blue-600">Dice simulator</h3>
+                <div class="mt-1 flex flex-wrap gap-2">
+                    <span class="inline-block px-3 py-1 text-sm font-semibold text-amber-600 border border-amber-500 rounded-full bg-amber-50">javascript</span>
+                </div>
                 <p class="text-gray-700">
                     Generate probability distribution tables from custom sets of dice.
                 </p>


### PR DESCRIPTION
### Motivation

- Improve project discoverability by surfacing technology and topic tags next to projects.  
- Make project listings more concise and consistent with simplified titles.  
- Provide visual grouping using existing Tailwind utility classes for a cohesive UI.

### Description

- Added a tag badge block at the top of the Projects section in `public/index.html` and added technology/topic badges to many individual project cards across `public/index.html` and `public/other_projects.html`.  
- Simplified and normalized several project titles (for example `Anscombe's Quartet Research` -> `Anscombes`, `Infinite Mind Games – Wiki Docs` -> `Wiki docs`, `Defender Remake on Atari ST` -> `Defender remake`) and adjusted casing for other titles.  
- Introduced consistent Tailwind-based badge markup (`span` elements with utility classes) for each tag to ensure consistent spacing and colors across pages.  
- Minor content adjustments to project descriptions and links remained unchanged except for title and tag additions, and one title change to `Airplace Package Scheduler` in `public/other_projects.html`.

### Testing

- No automated tests were run for these static HTML changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f42139cd74832ba8e158d84d400092)