### PR TITLE
Add Go Library card to other projects page

### DIFF
--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -55,6 +55,12 @@
                     Generate probability distribution tables from custom sets of dice.
                 </p>
             </a>
+            <a href="https://github.com/axyl-casc/GoLibrary" class="project-card">
+                <h3 class="font-semibold text-blue-600">Go Library</h3>
+                <p class="text-gray-700">
+                    An offline-first bookshelf experience for Baduk/Go materials. The project combines a Node.js + Express backend with a React front-end to organize and view PDF, SGF, and HTML resources. The backend indexes the local library, generates thumbnails, and persists user-specific state in SQLite. The front-end offers a rich shelf UI with favorites, bookmarks, and resumable reading positions.
+                </p>
+            </a>
         </div>
     </main>
 


### PR DESCRIPTION
### Motivation
- Add a visible entry for the `GoLibrary` project to the site’s other projects listing so visitors can discover the repository and its offline-first bookshelf features.

### Description
- Inserted a new project card linking to `https://github.com/axyl-casc/GoLibrary` into `public/other_projects.html` and included the README description describing the Node.js/Express backend, React front-end, and key features.

### Testing
- No automated tests were required for this static HTML content change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faed184c6c832b9faa7809bcb2dd95)