### PR TITLE
Shorten Go Library card copy on projects page

### DIFF
--- a/public/other_projects.html
+++ b/public/other_projects.html
@@ -58,7 +58,7 @@
             <a href="https://github.com/axyl-casc/GoLibrary" class="project-card">
                 <h3 class="font-semibold text-blue-600">Go Library</h3>
                 <p class="text-gray-700">
-                    An offline-first bookshelf experience for Baduk/Go materials. The project combines a Node.js + Express backend with a React front-end to organize and view PDF, SGF, and HTML resources. The backend indexes the local library, generates thumbnails, and persists user-specific state in SQLite. The front-end offers a rich shelf UI with favorites, bookmarks, and resumable reading positions.
+                    Offline-first bookshelf for Go materials, with search, bookmarks, and resume tracking across PDF/SGF/HTML files.
                 </p>
             </a>
         </div>


### PR DESCRIPTION
### Motivation
- The Go Library project card description in `public/other_projects.html` was too long for the card layout and needed a concise summary.

### Description
- Replaced the long multi-sentence description with a single concise sentence in `public/other_projects.html` describing the project as an offline-first bookshelf with search, bookmarks, and resume tracking across PDF/SGF/HTML files.

### Testing
- No automated tests were required for this static text-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69faefa986b0832b8095b73aa066be58)