### PR TITLE
Add DaisyUI theme controller and light/dark themes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,24 @@
+import { useEffect, useState } from 'react';
 import { Layout } from './layouts/Layout';
 import { HomePage } from './pages/HomePage';
 import { OtherProjectsPage } from './pages/OtherProjectsPage';
 
 function App() {
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const stored = localStorage.getItem('theme');
+    return stored === 'dark' ? 'dark' : 'light';
+  });
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
   const isOtherProjects = window.location.pathname.includes('other_projects');
 
   if (isOtherProjects) {
     return (
-      <Layout title="Projects" subtitle="Explore my other projects.">
+      <Layout title="Projects" subtitle="Explore my other projects." theme={theme} onThemeChange={setTheme}>
         <OtherProjectsPage />
       </Layout>
     );
@@ -17,6 +28,8 @@ function App() {
     <Layout
       title="Axyl Carefoot-Schulz"
       subtitle="Software Developer | Building Scalable and User Focused Applications | Full Stack Development"
+      theme={theme}
+      onThemeChange={setTheme}
     >
       <HomePage />
     </Layout>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,22 @@
+import { ThemeController } from './ThemeController';
+
 type NavLink = { label: string; href: string };
 
 type HeaderProps = {
   title: string;
   subtitle: string;
   links: NavLink[];
+  theme: 'light' | 'dark';
+  onThemeChange: (theme: 'light' | 'dark') => void;
 };
 
-export function Header({ title, subtitle, links }: HeaderProps) {
+export function Header({ title, subtitle, links, theme, onThemeChange }: HeaderProps) {
   return (
     <header className="site-header">
-      <div className="container mx-auto text-center py-10">
+      <div className="container mx-auto text-center py-10 relative">
+        <div className="absolute right-2 top-2">
+          <ThemeController theme={theme} onChange={onThemeChange} />
+        </div>
         <h1 className="text-4xl font-bold">{title}</h1>
         <p className="mt-2 text-lg">{subtitle}</p>
         <nav className="flex justify-center space-x-4 mt-4">

--- a/src/components/ThemeController.tsx
+++ b/src/components/ThemeController.tsx
@@ -1,0 +1,36 @@
+type ThemeControllerProps = {
+  theme: 'light' | 'dark';
+  onChange: (theme: 'light' | 'dark') => void;
+};
+
+export function ThemeController({ theme, onChange }: ThemeControllerProps) {
+  return (
+    <label className="cursor-pointer grid place-items-center" aria-label="Theme toggle">
+      <input
+        type="checkbox"
+        value="dark"
+        className="toggle theme-controller bg-base-content col-span-2 col-start-1 row-start-1"
+        checked={theme === 'dark'}
+        onChange={(event) => onChange(event.target.checked ? 'dark' : 'light')}
+      />
+      <svg
+        className="stroke-base-100 fill-base-100 col-start-1 row-start-1"
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+      >
+        <path d="M5.64,17l-.71.71a1,1,0,0,0,0,1.41,1,1,0,0,0,1.41,0l.71-.71a1,1,0,0,0-1.41-1.41ZM5,12a1,1,0,0,0-1-1H3a1,1,0,0,0,0,2H4A1,1,0,0,0,5,12ZM12,5a1,1,0,0,0,1-1V3a1,1,0,0,0-2,0V4A1,1,0,0,0,12,5Zm5.66,2.34a1,1,0,0,0,.7-.29l.71-.71a1,1,0,1,0-1.41-1.41l-.71.71a1,1,0,0,0,.71,1.7ZM21,11H20a1,1,0,0,0,0,2h1a1,1,0,0,0,0-2Zm-9,2a1,1,0,1,0-1-1A1,1,0,0,0,12,13Zm6.36,4a1,1,0,0,0-1.41,1.41l.71.71a1,1,0,0,0,1.41-1.41ZM12,6a6,6,0,1,0,6,6A6,6,0,0,0,12,6Zm0,10a4,4,0,1,1,4-4A4,4,0,0,1,12,16Z" />
+      </svg>
+      <svg
+        className="stroke-base-100 fill-base-100 col-start-2 row-start-1"
+        xmlns="http://www.w3.org/2000/svg"
+        width="14"
+        height="14"
+        viewBox="0 0 24 24"
+      >
+        <path d="M21.64,13a1,1,0,0,0-1.05-.14,8.05,8.05,0,0,1-3.37.73A8.15,8.15,0,0,1,9.08,5.49a8.59,8.59,0,0,1,.25-2A1,1,0,0,0,8,2.36,10.14,10.14,0,1,0,22,14.05,1,1,0,0,0,21.64,13Zm-9.5,6.69A8.14,8.14,0,0,1,7.08,5.22v.27A10.15,10.15,0,0,0,17.22,15.63a9.79,9.79,0,0,0,2.1-.22A8.11,8.11,0,0,1,12.14,19.73Z" />
+      </svg>
+    </label>
+  );
+}

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -6,6 +6,8 @@ type LayoutProps = {
   title: string;
   subtitle: string;
   children: ReactNode;
+  theme: 'light' | 'dark';
+  onThemeChange: (theme: 'light' | 'dark') => void;
 };
 
 const links = [
@@ -14,10 +16,10 @@ const links = [
   { label: 'LinkedIn', href: 'https://www.linkedin.com/in/axyl-carefoot-schulz-7b3024200/' }
 ];
 
-export function Layout({ title, subtitle, children }: LayoutProps) {
+export function Layout({ title, subtitle, children, theme, onThemeChange }: LayoutProps) {
   return (
-    <div className="bg-gray-100 text-gray-800 font-sans leading-normal tracking-normal min-h-screen flex flex-col">
-      <Header title={title} subtitle={subtitle} links={links} />
+    <div className="bg-base-200 text-base-content font-sans leading-normal tracking-normal min-h-screen flex flex-col">
+      <Header title={title} subtitle={subtitle} links={links} theme={theme} onThemeChange={onThemeChange} />
       {children}
       <Footer />
     </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -4,7 +4,7 @@
 
 @layer components {
   .site-header {
-    @apply bg-gradient-to-r from-blue-700 via-indigo-600 to-purple-700 text-white p-8 rounded-b-lg shadow-lg;
+    @apply bg-primary text-primary-content p-8 rounded-b-lg shadow-lg;
   }
 
   .site-main {
@@ -12,10 +12,10 @@
   }
 
   .site-footer {
-    @apply bg-gray-900 text-white p-4 mt-8 text-center;
+    @apply bg-neutral text-neutral-content p-4 mt-8 text-center;
   }
 
   .project-card {
-    @apply block p-4 bg-white rounded border border-gray-300 shadow hover:bg-gray-100 hover:border-blue-600 transform hover:-translate-y-1 hover:shadow-lg transition;
+    @apply block p-4 bg-base-100 rounded border border-base-300 shadow hover:bg-base-200 hover:border-primary transform hover:-translate-y-1 hover:shadow-lg transition;
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,6 +7,6 @@ export default {
   },
   plugins: [require('daisyui')],
   daisyui: {
-    themes: ['light']
+    themes: ['light', 'dark']
   }
 } satisfies Config;


### PR DESCRIPTION
### Motivation

- Provide a user-facing theme switcher so the site can toggle between light and dark color schemes using DaisyUI's theme system.
- Keep the `light` theme as the default and add `dark` as an alternative in the Tailwind/DaisyUI configuration.
- Use the DaisyUI `theme-controller` pattern so the toggle visually matches DaisyUI components.

### Description

- Updated `tailwind.config.ts` to register both `light` and `dark` themes for DaisyUI by adding `themes: ['light', 'dark']`.
- Added a new `ThemeController` component at `src/components/ThemeController.tsx` that implements a DaisyUI-style toggle with sun/moon icons.
- Wired theme state through `src/App.tsx` (React state + `useEffect`), passed props into `Layout` and `Header`, and applied the active theme via `document.documentElement.setAttribute('data-theme', theme)` while persisting the selection in `localStorage`.
- Updated `src/layouts/Layout.tsx`, `src/components/Header.tsx`, and `src/styles/index.css` to use DaisyUI semantic tokens (`bg-primary`, `text-primary-content`, `bg-neutral`, `bg-base-100`, `border-base-300`, etc.) so components adapt to both themes.

### Testing

- Ran `npm run build` to validate the change, which triggered the TypeScript + Vite build pipeline.
- The build failed in this environment due to missing frontend dependencies/type declarations (errors such as missing `react` and `react/jsx-runtime`), so no successful build artifact was produced; these errors are environment dependency issues and not caused by the theme-controller code itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0007f1b338832b9e3f3ed1bd46888b)