### PR TITLE
Update project card text colors for dark/light theme switching

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -5,8 +5,8 @@ export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: bo
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
         <a key={item.href} href={item.href} className="project-card">
-          <h3 className="font-semibold text-blue-600">{item.title}</h3>
-          <p className="text-gray-700">{item.description}</p>
+          <h3 className="font-semibold text-primary">{item.title}</h3>
+          <p className="text-base-content/80">{item.description}</p>
         </a>
       ))}
     </div>


### PR DESCRIPTION
### Motivation
- Replace fixed light-theme Tailwind classes with theme-aware tokens so project cards adapt properly to dark and light modes.

### Description
- Change title class from `text-blue-600` to `text-primary` and description class from `text-gray-700` to `text-base-content/80` in `src/components/CardGrid.tsx`.

### Testing
- Ran basic repo checks: `git status --short`, `nl -ba src/components/CardGrid.tsx | sed -n '1,120p'`, and `git commit`, and each command completed successfully; no full test suite was executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00094ff24c832b85bdc15af748b84c)