### PR TITLE
Use DaisyUI card component for project cards

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -4,9 +4,11 @@ export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: bo
   return (
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
-        <a key={item.href} href={item.href} className="project-card">
-          <h3 className="font-semibold text-primary">{item.title}</h3>
-          <p className="text-base-content/80">{item.description}</p>
+        <a key={item.href} href={item.href} className="card bg-base-100 border border-base-300 shadow-sm hover:shadow-lg transition-shadow duration-200">
+          <div className="card-body">
+            <h3 className="card-title text-primary">{item.title}</h3>
+            <p className="text-base-content/80">{item.description}</p>
+          </div>
         </a>
       ))}
     </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -15,7 +15,4 @@
     @apply bg-neutral text-neutral-content p-4 mt-8 text-center;
   }
 
-  .project-card {
-    @apply block p-4 bg-base-100 rounded border border-base-300 shadow hover:bg-base-200 hover:border-primary transform hover:-translate-y-1 hover:shadow-lg transition;
-  }
 }


### PR DESCRIPTION
### Motivation
- Replace the ad-hoc `.project-card` markup with DaisyUI's `card` component to align with the site's component library and DaisyUI patterns.
- Remove the custom project-card styles so visual behavior is handled by DaisyUI utility classes instead of bespoke CSS.

### Description
- Updated `src/components/CardGrid.tsx` to use DaisyUI markup by replacing the `project-card` anchor with `className="card ..."` and adding a `div.card-body` wrapper. 
- Rendered the title with `card-title` and preserved the prior text and color classes for the description. 
- Removed the unused `.project-card` style block from `src/styles/index.css` to avoid duplicate styling.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/TypeScript dependencies and missing `react/jsx-runtime` type declarations; the failure is a pre-existing environment setup issue and not caused by these markup-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000a02c518832b8595fe90a94c395a)