### PR TITLE
Add dedicated project detail pages and internal routing for portfolio projects

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { Layout } from './layouts/Layout';
 import { HomePage } from './pages/HomePage';
 import { OtherProjectsPage } from './pages/OtherProjectsPage';
+import { ProjectPage } from './pages/ProjectPage';
+import { projects } from './projects';
 
 function App() {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
@@ -14,7 +16,18 @@ function App() {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
-  const isOtherProjects = window.location.pathname.includes('other_projects');
+  const path = window.location.pathname;
+  const isOtherProjects = path.includes('other_projects');
+  const projectMatch = path.match(/^\/projects\/([^/]+)\/?$/);
+  const project = projectMatch ? projects.find((item) => item.slug === projectMatch[1]) : undefined;
+
+  if (project) {
+    return (
+      <Layout title="Project" subtitle="Project details and links." theme={theme} onThemeChange={setTheme}>
+        <ProjectPage project={project} />
+      </Layout>
+    );
+  }
 
   if (isOtherProjects) {
     return (

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,15 +1,21 @@
 import { CardGrid } from '../components/CardGrid';
 import { Section } from '../components/Section';
+import { projects } from '../projects';
 import type { CardItem } from '../types';
 
-const projects: CardItem[] = [
-  { title: "Anscombe's Quartet Research", href: 'https://github.com/axyl-casc/Anscombes_Research?tab=readme-ov-file#anscombes-quartet-research-project', description: "Created a program to replicate Anscombe's Quartet, emphasizing the importance of visual data analysis." },
-  { title: 'Infinite Mind Games – Wiki Docs', href: 'https://infinite-mind-pictures-inc.github.io/Infinite-Mind-Wiki/', description: 'An interactive documentation site built with Quartz, featuring guides, learning modules, and development notes for Infinite Mind Games projects.' },
-  { title: 'Beginner GO AI Game', href: 'https://zxnashx.itch.io/beginner-go-game', description: 'A GO playing interface designed to teach beginners how to play the game of GO.' },
-  { title: 'Fancy Pants Outfitters (React Demo)', href: 'https://acare3.github.io/4513_2_website/', description: 'A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.' },
-  { title: 'Defender Remake on Atari ST', href: 'https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender', description: 'Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.' },
-  { title: 'Linux Shell Development', href: 'https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell', description: 'Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.' },
-  { title: 'Other Projects', href: '/other_projects', description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.' }
+const featuredProjects: CardItem[] = [
+  ...projects
+    .filter((project) => project.section === 'featured')
+    .map((project) => ({
+      title: project.title,
+      href: `/projects/${project.slug}`,
+      description: project.description
+    })),
+  {
+    title: 'Other Projects',
+    href: '/other_projects',
+    description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.'
+  }
 ];
 
 const hobbies: CardItem[] = [
@@ -52,39 +58,18 @@ export function HomePage() {
           </p>
 
           <ul className="list-disc pl-6 space-y-2">
-            <li>
-              <strong>Software Development:</strong> Algorithm design,
-              system-level programming, data-driven application development,
-              and backend logic
-            </li>
-
-            <li>
-              <strong>Web Development:</strong> React, Tailwind CSS, TSX
-              component editing, Quartz 4, Node.js, and Electron
-            </li>
-
-            <li>
-              <strong>Data & Visualization:</strong> MySQL, stored procedures,
-              data integrity management, Matplotlib, NumPy, and SymPy
-            </li>
-
-            <li>
-              <strong>Mathematics & Modelling:</strong> Linear algebra,
-              discrete mathematics, calculus, statistics, network science, and
-              mathematical modelling
-            </li>
-
-            <li>
-              <strong>Teaching & Mentoring:</strong> Python, SQL, and Java
-              instruction, curriculum development, and hands-on coding activities
-            </li>
+            <li><strong>Software Development:</strong> Algorithm design, system-level programming, data-driven application development, and backend logic</li>
+            <li><strong>Web Development:</strong> React, Tailwind CSS, TSX component editing, Quartz 4, Node.js, and Electron</li>
+            <li><strong>Data & Visualization:</strong> MySQL, stored procedures, data integrity management, Matplotlib, NumPy, and SymPy</li>
+            <li><strong>Mathematics & Modelling:</strong> Linear algebra, discrete mathematics, calculus, statistics, network science, and mathematical modelling</li>
+            <li><strong>Teaching & Mentoring:</strong> Python, SQL, and Java instruction, curriculum development, and hands-on coding activities</li>
           </ul>
         </div>
       </Section>
 
       <Section title="Projects">
         <div className="space-y-6">
-          <CardGrid items={projects} />
+          <CardGrid items={featuredProjects} />
         </div>
       </Section>
 

--- a/src/pages/OtherProjectsPage.tsx
+++ b/src/pages/OtherProjectsPage.tsx
@@ -1,14 +1,14 @@
 import { CardGrid } from '../components/CardGrid';
+import { projects } from '../projects';
 import type { CardItem } from '../types';
 
-const items: CardItem[] = [
-  { title: 'CPU Scheduler', href: 'https://axyl-casc.github.io/Scheduler-Designer/', description: 'Run different CPU scheduling algorithms interactively and view the results afterwards.' },
-  { title: 'Airplane Package Scheduler', href: 'https://github.com/axyl-casc/AirplaneGraphProject?tab=readme-ov-file#readme', description: 'Effectively calculates possible routes for airplanes to deliver packages with a version made in Javascript and Haskell.' },
-  { title: 'Daily Training Game', href: 'https://axyl-casc.github.io/TrainingGame/', description: 'A daily to-do list app I use for language learning and tracking whatever currently interests me.' },
-  { title: 'GoGuesser', href: 'https://goguesser.onrender.com/', description: 'Guess the next best move in a Go game.' },
-  { title: 'Dice Simulator', href: 'https://axyl-casc.github.io/Dice-Simulator/', description: 'Generate probability distribution tables from custom sets of dice.' },
-  { title: 'Go Library', href: 'https://github.com/axyl-casc/GoLibrary', description: 'Offline-first bookshelf for Go materials, with search, bookmarks, and resume tracking across PDF/SGF/HTML files.' }
-];
+const items: CardItem[] = projects
+  .filter((project) => project.section === 'other')
+  .map((project) => ({
+    title: project.title,
+    href: `/projects/${project.slug}`,
+    description: project.description
+  }));
 
 export function OtherProjectsPage() {
   return (

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,0 +1,17 @@
+import type { Project } from '../types';
+
+export function ProjectPage({ project }: { project: Project }) {
+  return (
+    <main className="site-main flex-1">
+      <section className="max-w-3xl mx-auto card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card-body space-y-4">
+          <h2 className="text-3xl font-bold text-primary">{project.title}</h2>
+          <p className="text-base-content/80">{project.description}</p>
+          <div className="pt-2">
+            <a href={project.projectUrl} className="btn btn-primary" target="_blank" rel="noreferrer">Visit Project</a>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -1,0 +1,88 @@
+import type { Project } from './types';
+
+export const projects: Project[] = [
+  {
+    slug: 'anscombes-quartet-research',
+    title: "Anscombe's Quartet Research",
+    description: "Created a program to replicate Anscombe's Quartet, emphasizing the importance of visual data analysis.",
+    projectUrl: 'https://github.com/axyl-casc/Anscombes_Research?tab=readme-ov-file#anscombes-quartet-research-project',
+    section: 'featured'
+  },
+  {
+    slug: 'infinite-mind-games-wiki-docs',
+    title: 'Infinite Mind Games – Wiki Docs',
+    description: 'An interactive documentation site built with Quartz, featuring guides, learning modules, and development notes for Infinite Mind Games projects.',
+    projectUrl: 'https://infinite-mind-pictures-inc.github.io/Infinite-Mind-Wiki/',
+    section: 'featured'
+  },
+  {
+    slug: 'beginner-go-ai-game',
+    title: 'Beginner GO AI Game',
+    description: 'A GO playing interface designed to teach beginners how to play the game of GO.',
+    projectUrl: 'https://zxnashx.itch.io/beginner-go-game',
+    section: 'featured'
+  },
+  {
+    slug: 'fancy-pants-outfitters-react-demo',
+    title: 'Fancy Pants Outfitters (React Demo)',
+    description: 'A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.',
+    projectUrl: 'https://acare3.github.io/4513_2_website/',
+    section: 'featured'
+  },
+  {
+    slug: 'defender-remake-atari-st',
+    title: 'Defender Remake on Atari ST',
+    description: 'Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.',
+    projectUrl: 'https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender',
+    section: 'featured'
+  },
+  {
+    slug: 'linux-shell-development',
+    title: 'Linux Shell Development',
+    description: 'Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.',
+    projectUrl: 'https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell',
+    section: 'featured'
+  },
+  {
+    slug: 'cpu-scheduler',
+    title: 'CPU Scheduler',
+    description: 'Run different CPU scheduling algorithms interactively and view the results afterwards.',
+    projectUrl: 'https://axyl-casc.github.io/Scheduler-Designer/',
+    section: 'other'
+  },
+  {
+    slug: 'airplane-package-scheduler',
+    title: 'Airplane Package Scheduler',
+    description: 'Effectively calculates possible routes for airplanes to deliver packages with a version made in Javascript and Haskell.',
+    projectUrl: 'https://github.com/axyl-casc/AirplaneGraphProject?tab=readme-ov-file#readme',
+    section: 'other'
+  },
+  {
+    slug: 'daily-training-game',
+    title: 'Daily Training Game',
+    description: 'A daily to-do list app I use for language learning and tracking whatever currently interests me.',
+    projectUrl: 'https://axyl-casc.github.io/TrainingGame/',
+    section: 'other'
+  },
+  {
+    slug: 'goguesser',
+    title: 'GoGuesser',
+    description: 'Guess the next best move in a Go game.',
+    projectUrl: 'https://goguesser.onrender.com/',
+    section: 'other'
+  },
+  {
+    slug: 'dice-simulator',
+    title: 'Dice Simulator',
+    description: 'Generate probability distribution tables from custom sets of dice.',
+    projectUrl: 'https://axyl-casc.github.io/Dice-Simulator/',
+    section: 'other'
+  },
+  {
+    slug: 'go-library',
+    title: 'Go Library',
+    description: 'Offline-first bookshelf for Go materials, with search, bookmarks, and resume tracking across PDF/SGF/HTML files.',
+    projectUrl: 'https://github.com/axyl-casc/GoLibrary',
+    section: 'other'
+  }
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,11 @@ export type CardItem = {
   description: string;
   href: string;
 };
+
+export type Project = {
+  slug: string;
+  title: string;
+  description: string;
+  projectUrl: string;
+  section: 'featured' | 'other';
+};


### PR DESCRIPTION
### Motivation
- Provide each project with its own internal page that shows a title, description, and a button to visit the real project.  
- Centralize project metadata to avoid duplicated external links and make per-project routing possible.  
- Ensure both featured and other projects link to internal routes (`/projects/:slug`) for a consistent UX.

### Description
- Added a new `Project` type to `src/types.ts` and created a centralized `src/projects.ts` list containing `slug`, `title`, `description`, `projectUrl`, and `section` for every project.  
- Implemented `src/pages/ProjectPage.tsx` (`ProjectPage`) which renders a project title, description, and a `Visit Project` button that opens `project.projectUrl`.  
- Updated `src/pages/HomePage.tsx` and `src/pages/OtherProjectsPage.tsx` to map project entries to internal links at `/projects/:slug` and to consume the centralized `projects` data.  
- Updated `src/App.tsx` to detect `/projects/:slug` paths and render the `ProjectPage` for the matched project.

### Testing
- Ran `npm run build`, which failed due to missing React/Vite type/dependency files in the environment (TypeScript errors about missing `react` / `react/jsx-runtime` and Vite types), so the production build could not be completed here; this is an environment dependency issue rather than a change in feature logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000dbcf57c832baa8649f03dc7d877)