### PR TITLE
Refactor homepage tags into section data modules

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -8,6 +8,15 @@ export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: bo
           <div className="card-body">
             <h3 className="card-title text-primary">{item.title}</h3>
             <p className="text-base-content/80">{item.description}</p>
+            {item.tags && item.tags.length > 0 && (
+              <div className="card-actions pt-2">
+                {item.tags.map((tag) => (
+                  <div key={tag} className="badge badge-outline">
+                    {tag}
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
         </a>
       ))}

--- a/src/experience.tsx
+++ b/src/experience.tsx
@@ -1,0 +1,34 @@
+export type ExperienceItem = {
+  title: string;
+  meta: string;
+  details: string[];
+  tags: string[];
+};
+
+export const experienceItems: ExperienceItem[] = [
+  {
+    title: 'Web Development Intern',
+    meta: 'Infinite Mind Pictures Inc. · June 2025 – September 2025 · Calgary, AB',
+    details: [
+      'Helped lead the development of an internal wiki using Quartz 4, a React-based framework, to improve organization, communication, and resource sharing across the team. My work included refining visual design, improving user experience, editing custom TSX components, and building a clearer structure for team knowledge and support resources.',
+      'I also created a resource portal for Infinite Mind’s neurodivergent community and partners, with an emphasis on accessibility, clarity, and inclusive UI/UX design. Alongside this, I developed a Java programming course for kids using Robocode, designing interactive lessons and activities that introduced core programming concepts through game-based learning.'
+    ],
+    tags: ['Quartz 4', 'React', 'UI/UX', 'Education']
+  },
+  {
+    title: 'Programming Tutor',
+    meta: 'Launch Pad Learning · May 2023 – January 2025 · Calgary, AB',
+    details: [
+      'Taught programming fundamentals to students ranging from children to adults, with a focus on Python, SQL, Java, and practical problem-solving. Designed hands-on activities, custom exercises, and coding lessons that helped students build confidence with core programming concepts and best practices.'
+    ],
+    tags: ['Python', 'SQL', 'Java', 'Mentoring']
+  },
+  {
+    title: 'Mover & IT Support',
+    meta: 'Darwin’s Moving & Deliveries · July 2018 – August 2020 · Calgary, AB',
+    details: [
+      'Provided technical setup and troubleshooting support for client devices, company computers, and hardware/software issues. This role strengthened my practical troubleshooting skills, communication, and ability to solve technical problems in real-world environments.'
+    ],
+    tags: ['IT Support', 'Troubleshooting', 'Hardware', 'Communication']
+  }
+];

--- a/src/hobbies.tsx
+++ b/src/hobbies.tsx
@@ -1,0 +1,22 @@
+import type { CardItem } from './types';
+
+export const hobbies: CardItem[] = [
+  {
+    title: 'Baduk / GO',
+    href: 'https://online-go.com/user/view/1071783',
+    description: 'I enjoy studying and playing GO (Baduk), from tactical puzzles to longer, strategic games online.',
+    tags: ['Baduk / Go', 'Strategy', 'Pattern Recognition']
+  },
+  {
+    title: 'Rock Climbing',
+    href: 'https://www.instagram.com/axyl.sc/',
+    description: 'Bouldering and climbing help me stay active, solve movement problems, and keep improving technique.',
+    tags: ['Bouldering', 'Problem Solving', 'Fitness']
+  },
+  {
+    title: 'Bird Watching',
+    href: 'https://ebird.org/profile/Nzc4Nzg0NQ',
+    description: 'I like tracking sightings, identifying species, and exploring local habitats through birding.',
+    tags: ['Observation', 'Nature', 'Tracking']
+  }
+];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,28 +1,8 @@
 import { CardGrid } from '../components/CardGrid';
 import { Section } from '../components/Section';
-import { projects } from '../projects';
-import type { CardItem } from '../types';
-
-const featuredProjects: CardItem[] = [
-  ...projects
-    .filter((project) => project.section === 'featured')
-    .map((project) => ({
-      title: project.title,
-      href: `/projects/${project.slug}`,
-      description: project.description
-    })),
-  {
-    title: 'Other Projects',
-    href: '/other_projects',
-    description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.'
-  }
-];
-
-const hobbies: CardItem[] = [
-  { title: 'Baduk / GO', href: 'https://online-go.com/user/view/1071783', description: 'I enjoy studying and playing GO (Baduk), from tactical puzzles to longer, strategic games online.' },
-  { title: 'Rock Climbing', href: 'https://www.instagram.com/axyl.sc/', description: 'Bouldering and climbing help me stay active, solve movement problems, and keep improving technique.' },
-  { title: 'Bird Watching', href: 'https://ebird.org/profile/Nzc4Nzg0NQ', description: 'I like tracking sightings, identifying species, and exploring local habitats through birding.' }
-];
+import { experienceItems } from '../experience';
+import { hobbies } from '../hobbies';
+import { featuredProjects } from '../projectsCards';
 
 export function HomePage() {
   return (
@@ -136,13 +116,6 @@ export function HomePage() {
       <div className="divider my-1"></div>
 
       <CardGrid items={featuredProjects} />
-
-      <div className="card-actions">
-        <div className="badge badge-primary">Go / Baduk</div>
-        <div className="badge badge-secondary">Web Development</div>
-        <div className="badge badge-accent">Systems Programming</div>
-        <div className="badge badge-outline">Data Visualization</div>
-      </div>
     </div>
   </div>
 </Section>
@@ -158,97 +131,33 @@ export function HomePage() {
       <div className="divider my-1"></div>
 
       <div className="space-y-6">
-        <div className="card bg-base-100 shadow-sm">
-          <div className="card-body space-y-2">
-            <h3 className="card-title text-base">
-              Web Development Intern
-            </h3>
-
-            <p className="text-sm opacity-70">
-              Infinite Mind Pictures Inc. · June 2025 – September 2025 ·
-              Calgary, AB
-            </p>
-
-            <p>
-              Helped lead the development of an internal wiki using Quartz 4, a
-              React-based framework, to improve organization, communication, and
-              resource sharing across the team. My work included refining visual
-              design, improving user experience, editing custom TSX components,
-              and building a clearer structure for team knowledge and support
-              resources.
-            </p>
-
-            <p>
-              I also created a resource portal for Infinite Mind’s
-              neurodivergent community and partners, with an emphasis on
-              accessibility, clarity, and inclusive UI/UX design. Alongside this,
-              I developed a Java programming course for kids using Robocode,
-              designing interactive lessons and activities that introduced core
-              programming concepts through game-based learning.
-            </p>
-
-            <div className="card-actions pt-2">
-              <div className="badge badge-primary">Quartz 4</div>
-              <div className="badge badge-secondary">React</div>
-              <div className="badge badge-accent">UI/UX</div>
-              <div className="badge badge-outline">Education</div>
+        {experienceItems.map((item) => (
+          <div key={item.title} className="card bg-base-100 shadow-sm">
+            <div className="card-body space-y-2">
+              <h3 className="card-title text-base">{item.title}</h3>
+              <p className="text-sm opacity-70">{item.meta}</p>
+              {item.details.map((detail) => (
+                <p key={detail}>{detail}</p>
+              ))}
+              <div className="card-actions pt-2">
+                {item.tags.map((tag, index) => (
+                  <div
+                    key={tag}
+                    className={[
+                      'badge',
+                      index === 0 ? 'badge-primary' : '',
+                      index === 1 ? 'badge-secondary' : '',
+                      index === 2 ? 'badge-accent' : '',
+                      index > 2 ? 'badge-outline' : ''
+                    ].join(' ').trim()}
+                  >
+                    {tag}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-        </div>
-
-        <div className="card bg-base-100 shadow-sm">
-          <div className="card-body space-y-2">
-            <h3 className="card-title text-base">
-              Programming Tutor
-            </h3>
-
-            <p className="text-sm opacity-70">
-              Launch Pad Learning · May 2023 – January 2025 · Calgary, AB
-            </p>
-
-            <p>
-              Taught programming fundamentals to students ranging from children
-              to adults, with a focus on Python, SQL, Java, and practical
-              problem-solving. Designed hands-on activities, custom exercises,
-              and coding lessons that helped students build confidence with core
-              programming concepts and best practices.
-            </p>
-
-            <div className="card-actions pt-2">
-              <div className="badge badge-primary">Python</div>
-              <div className="badge badge-secondary">SQL</div>
-              <div className="badge badge-accent">Java</div>
-              <div className="badge badge-outline">Mentoring</div>
-            </div>
-          </div>
-        </div>
-
-        <div className="card bg-base-100 shadow-sm">
-          <div className="card-body space-y-2">
-            <h3 className="card-title text-base">
-              Mover &amp; IT Support
-            </h3>
-
-            <p className="text-sm opacity-70">
-              Darwin’s Moving &amp; Deliveries · July 2018 – August 2020 ·
-              Calgary, AB
-            </p>
-
-            <p>
-              Provided technical setup and troubleshooting support for client
-              devices, company computers, and hardware/software issues. This role
-              strengthened my practical troubleshooting skills, communication,
-              and ability to solve technical problems in real-world environments.
-            </p>
-
-            <div className="card-actions pt-2">
-              <div className="badge badge-primary">IT Support</div>
-              <div className="badge badge-secondary">Troubleshooting</div>
-              <div className="badge badge-accent">Hardware</div>
-              <div className="badge badge-outline">Communication</div>
-            </div>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   </div>
@@ -267,13 +176,6 @@ export function HomePage() {
       <div className="divider my-1"></div>
 
       <CardGrid items={hobbies} />
-
-      <div className="card-actions">
-        <div className="badge badge-primary">Baduk / Go</div>
-        <div className="badge badge-secondary">Rock Climbing</div>
-        <div className="badge badge-accent">Bird Watching</div>
-        <div className="badge badge-outline">Strategy</div>
-      </div>
     </div>
   </div>
 </Section>

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -6,83 +6,95 @@ export const projects: Project[] = [
     title: "Anscombe's Quartet Research",
     description: "Created a program to replicate Anscombe's Quartet, emphasizing the importance of visual data analysis.",
     projectUrl: 'https://github.com/axyl-casc/Anscombes_Research?tab=readme-ov-file#anscombes-quartet-research-project',
-    section: 'featured'
+    section: 'featured',
+    tags: ['Data Analysis', 'Research', 'Python']
   },
   {
     slug: 'infinite-mind-games-wiki-docs',
     title: 'Infinite Mind Games – Wiki Docs',
     description: 'An interactive documentation site built with Quartz, featuring guides, learning modules, and development notes for Infinite Mind Games projects.',
     projectUrl: 'https://infinite-mind-pictures-inc.github.io/Infinite-Mind-Wiki/',
-    section: 'featured'
+    section: 'featured',
+    tags: ['Quartz', 'Documentation', 'Web Development']
   },
   {
     slug: 'beginner-go-ai-game',
     title: 'Beginner GO AI Game',
     description: 'A GO playing interface designed to teach beginners how to play the game of GO.',
     projectUrl: 'https://zxnashx.itch.io/beginner-go-game',
-    section: 'featured'
+    section: 'featured',
+    tags: ['Go / Baduk', 'Game Development', 'Education']
   },
   {
     slug: 'fancy-pants-outfitters-react-demo',
     title: 'Fancy Pants Outfitters (React Demo)',
     description: 'A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.',
     projectUrl: 'https://acare3.github.io/4513_2_website/',
-    section: 'featured'
+    section: 'featured',
+    tags: ['React', 'Frontend', 'E-commerce']
   },
   {
     slug: 'defender-remake-atari-st',
     title: 'Defender Remake on Atari ST',
     description: 'Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.',
     projectUrl: 'https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender',
-    section: 'featured'
+    section: 'featured',
+    tags: ['C', 'Assembly', 'Game Development']
   },
   {
     slug: 'linux-shell-development',
     title: 'Linux Shell Development',
     description: 'Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.',
     projectUrl: 'https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell',
-    section: 'featured'
+    section: 'featured',
+    tags: ['C', 'Systems Programming', 'Concurrency']
   },
   {
     slug: 'cpu-scheduler',
     title: 'CPU Scheduler',
     description: 'Run different CPU scheduling algorithms interactively and view the results afterwards.',
     projectUrl: 'https://axyl-casc.github.io/Scheduler-Designer/',
-    section: 'other'
+    section: 'other',
+    tags: ['Algorithms', 'Visualization', 'Education']
   },
   {
     slug: 'airplane-package-scheduler',
     title: 'Airplane Package Scheduler',
     description: 'Effectively calculates possible routes for airplanes to deliver packages with a version made in Javascript and Haskell.',
     projectUrl: 'https://github.com/axyl-casc/AirplaneGraphProject?tab=readme-ov-file#readme',
-    section: 'other'
+    section: 'other',
+    tags: ['JavaScript', 'Haskell', 'Graph Algorithms']
   },
   {
     slug: 'daily-training-game',
     title: 'Daily Training Game',
     description: 'A daily to-do list app I use for language learning and tracking whatever currently interests me.',
     projectUrl: 'https://axyl-casc.github.io/TrainingGame/',
-    section: 'other'
+    section: 'other',
+    tags: ['Productivity', 'Habit Tracking', 'Web App']
   },
   {
     slug: 'goguesser',
     title: 'GoGuesser',
     description: 'Guess the next best move in a Go game.',
     projectUrl: 'https://goguesser.onrender.com/',
-    section: 'other'
+    section: 'other',
+    tags: ['Go / Baduk', 'Puzzle', 'Web App']
   },
   {
     slug: 'dice-simulator',
     title: 'Dice Simulator',
     description: 'Generate probability distribution tables from custom sets of dice.',
     projectUrl: 'https://axyl-casc.github.io/Dice-Simulator/',
-    section: 'other'
+    section: 'other',
+    tags: ['Probability', 'Simulation', 'Visualization']
   },
   {
     slug: 'go-library',
     title: 'Go Library',
     description: 'Offline-first bookshelf for Go materials, with search, bookmarks, and resume tracking across PDF/SGF/HTML files.',
     projectUrl: 'https://github.com/axyl-casc/GoLibrary',
-    section: 'other'
+    section: 'other',
+    tags: ['Offline-first', 'Search', 'Go / Baduk']
   }
 ];

--- a/src/projectsCards.tsx
+++ b/src/projectsCards.tsx
@@ -1,0 +1,19 @@
+import { projects } from './projects';
+import type { CardItem } from './types';
+
+export const featuredProjects: CardItem[] = [
+  ...projects
+    .filter((project) => project.section === 'featured')
+    .map((project) => ({
+      title: project.title,
+      href: `/projects/${project.slug}`,
+      description: project.description,
+      tags: project.tags
+    })),
+  {
+    title: 'Other Projects',
+    href: '/other_projects',
+    description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.',
+    tags: ['Software Tools', 'Data Visualization', 'Experiments']
+  }
+];

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ export type CardItem = {
   title: string;
   description: string;
   href: string;
+  tags?: string[];
 };
 
 export type Project = {
@@ -10,4 +11,5 @@ export type Project = {
   description: string;
   projectUrl: string;
   section: 'featured' | 'other';
+  tags: string[];
 };


### PR DESCRIPTION
### Motivation
- Make homepage tag presentation consistent by showing tags inside each project/hobby/experience card instead of as a single list at the bottom of the section.
- Centralize card data so the homepage markup is simpler and the content (including tags) can be updated per-item in data modules.

### Description
- Added dedicated data modules `src/projectsCards.tsx`, `src/hobbies.tsx`, and `src/experience.tsx` and updated the homepage to import and render from those modules using `featuredProjects`, `hobbies`, and `experienceItems` respectively.
- Updated `src/components/CardGrid.tsx` to render per-item `tags` inside each card as badges when `item.tags` is present.
- Extended `src/types.ts` to include `tags` on `CardItem` (optional) and on `Project`, and added `tags` arrays to each entry in `src/projects.ts` so featured project cards can surface their own tags.
- Replaced the previous section-level aggregated tag lists in `src/pages/HomePage.tsx` with per-card rendering and converted the experience block to iterate `experienceItems` from `src/experience.tsx`.

### Testing
- Ran `npm run build` to validate the change; the build fails in this environment due to missing React/Vite modules and type declarations (pre-existing dependency/setup issue) and not because of the refactor.
- No other automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0011d964e0832b8e192a7ee287243b)