### PR TITLE
Set website favicon to icon.ico

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <link rel="canonical" href="https://axyl-casc.github.io/" />
     <meta name="google-site-verification" content="OSiyzNuZR7ms-ttPH_yH_Sn5-zGMMRIRo7uxLeycl5U" />
     <title>Axyl Carefoot-Schulz - Software Developer</title>
+    <link rel="icon" type="image/x-icon" href="/icon.ico" />
     <script type="application/ld+json">
       {
         "@context": "http://schema.org",


### PR DESCRIPTION
### Motivation
- Ensure the site explicitly references `icon.ico` so browsers display the intended favicon for the site.

### Description
- Add `<link rel="icon" type="image/x-icon" href="/icon.ico" />` to the `<head>` of `index.html`.

### Testing
- Verified the change with `git diff -- index.html` and committed the update with `git commit`, both of which completed successfully; no automated unit tests were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0012ed5014832bbff1b509f1460337)