### PR TITLE
Assign unique colors to every tag for light and dark themes

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -1,4 +1,6 @@
+import type { CSSProperties } from 'react';
 import type { CardItem } from '../types';
+import { getTagHue } from '../utils/tagColors';
 
 export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: boolean }) {
   return (
@@ -11,7 +13,7 @@ export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: bo
             {item.tags && item.tags.length > 0 && (
               <div className="card-actions pt-2">
                 {item.tags.map((tag) => (
-                  <div key={tag} className="badge badge-outline">
+                  <div key={tag} className="badge tag-badge" style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}>
                     {tag}
                   </div>
                 ))}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,8 +1,10 @@
+import type { CSSProperties } from 'react';
 import { CardGrid } from '../components/CardGrid';
 import { Section } from '../components/Section';
 import { experienceItems } from '../experience';
 import { hobbies } from '../hobbies';
 import { featuredProjects } from '../projectsCards';
+import { getTagHue } from '../utils/tagColors';
 
 export function HomePage() {
   return (
@@ -145,11 +147,9 @@ export function HomePage() {
                     key={tag}
                     className={[
                       'badge',
-                      index === 0 ? 'badge-primary' : '',
-                      index === 1 ? 'badge-secondary' : '',
-                      index === 2 ? 'badge-accent' : '',
-                      index > 2 ? 'badge-outline' : ''
+                      'tag-badge'
                     ].join(' ').trim()}
+                    style={{ '--tag-hue': getTagHue(`${item.title}-${index}-${tag}`) } as CSSProperties}
                   >
                     {tag}
                   </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -15,4 +15,16 @@
     @apply bg-neutral text-neutral-content p-4 mt-8 text-center;
   }
 
+  .tag-badge {
+    background-color: hsl(var(--tag-hue) 75% 90%);
+    border: 1px solid hsl(var(--tag-hue) 60% 55% / 0.45);
+    color: hsl(var(--tag-hue) 70% 25%);
+  }
+
+  :root[data-theme='dark'] .tag-badge {
+    background-color: hsl(var(--tag-hue) 45% 24%);
+    border: 1px solid hsl(var(--tag-hue) 70% 62% / 0.55);
+    color: hsl(var(--tag-hue) 90% 82%);
+  }
+
 }

--- a/src/utils/tagColors.ts
+++ b/src/utils/tagColors.ts
@@ -1,0 +1,8 @@
+export function getTagHue(tag: string): number {
+  let hash = 0;
+  for (let i = 0; i < tag.length; i += 1) {
+    hash = (hash * 31 + tag.charCodeAt(i)) % 360;
+  }
+
+  return hash;
+}


### PR DESCRIPTION
### Motivation
- Ensure every tag rendered in the site has a stable, unique color in both light and dark themes instead of falling back to outline styles.
- Keep tag colors deterministic and readable across themes so tags are visually distinct and accessible.

### Description
- Added `getTagHue` utility (`src/utils/tagColors.ts`) which deterministically hashes a tag string to a hue value used for coloring.
- Updated tag rendering in `CardGrid` (`src/components/CardGrid.tsx`) to apply a `tag-badge` class and set the computed hue via the CSS custom property `--tag-hue` using `getTagHue`.
- Updated Experience tags on the home page (`src/pages/HomePage.tsx`) to use the `tag-badge` pattern and compute per-tag hues (using a composite key of title/index/tag to avoid collisions).
- Added `tag-badge` styles in `src/styles/index.css` with distinct HSL rules for light and dark themes that consume `--tag-hue` to produce readable backgrounds, borders, and text colors.

### Testing
- Ran the build with `npm run build`; the build failed in this environment due to missing React/Vite/type dependencies unrelated to the tag color changes, so no full production build verification could be completed.
- Verified through static inspection that `getTagHue` is used where tags are rendered and that CSS custom property usage matches the new `tag-badge` rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0013185d68832b98eec219d97b7a3a)