### PR TITLE
Add hobbies landing and detail navigation flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,11 @@ import { useEffect, useState } from 'react';
 import { Layout } from './layouts/Layout';
 import { HomePage } from './pages/HomePage';
 import { OtherProjectsPage } from './pages/OtherProjectsPage';
+import { OtherHobbiesPage } from './pages/OtherHobbiesPage';
 import { ProjectPage } from './pages/ProjectPage';
+import { HobbyPage } from './pages/HobbyPage';
 import { projects } from './projects';
+import { hobbies } from './hobbies';
 
 function App() {
   const [theme, setTheme] = useState<'light' | 'dark'>(() => {
@@ -18,8 +21,11 @@ function App() {
 
   const path = window.location.pathname;
   const isOtherProjects = path.includes('other_projects');
+  const isOtherHobbies = path.includes('other_hobbies');
   const projectMatch = path.match(/^\/projects\/([^/]+)\/?$/);
+  const hobbyMatch = path.match(/^\/hobbies\/([^/]+)\/?$/);
   const project = projectMatch ? projects.find((item) => item.slug === projectMatch[1]) : undefined;
+  const hobby = hobbyMatch ? hobbies.find((item) => item.slug === hobbyMatch[1]) : undefined;
 
   if (project) {
     return (
@@ -29,10 +35,26 @@ function App() {
     );
   }
 
+  if (hobby) {
+    return (
+      <Layout title="Hobby" subtitle="Hobby details and links." theme={theme} onThemeChange={setTheme}>
+        <HobbyPage hobby={hobby} />
+      </Layout>
+    );
+  }
+
   if (isOtherProjects) {
     return (
       <Layout title="Projects" subtitle="Explore my other projects." theme={theme} onThemeChange={setTheme}>
         <OtherProjectsPage />
+      </Layout>
+    );
+  }
+
+  if (isOtherHobbies) {
+    return (
+      <Layout title="Hobbies" subtitle="Explore my other hobbies." theme={theme} onThemeChange={setTheme}>
+        <OtherHobbiesPage />
       </Layout>
     );
   }

--- a/src/hobbies.tsx
+++ b/src/hobbies.tsx
@@ -1,22 +1,28 @@
-import type { CardItem } from './types';
+import type { Hobby } from './types';
 
-export const hobbies: CardItem[] = [
+export const hobbies: Hobby[] = [
   {
+    slug: 'baduk-go',
     title: 'Baduk / GO',
-    href: 'https://online-go.com/user/view/1071783',
+    hobbyUrl: 'https://online-go.com/user/view/1071783',
     description: 'I enjoy studying and playing GO (Baduk), from tactical puzzles to longer, strategic games online.',
+    section: 'featured',
     tags: ['Baduk / Go', 'Strategy', 'Pattern Recognition']
   },
   {
+    slug: 'rock-climbing',
     title: 'Rock Climbing',
-    href: 'https://www.instagram.com/axyl.sc/',
+    hobbyUrl: 'https://www.instagram.com/axyl.sc/',
     description: 'Bouldering and climbing help me stay active, solve movement problems, and keep improving technique.',
+    section: 'featured',
     tags: ['Bouldering', 'Problem Solving', 'Fitness']
   },
   {
+    slug: 'bird-watching',
     title: 'Bird Watching',
-    href: 'https://ebird.org/profile/Nzc4Nzg0NQ',
+    hobbyUrl: 'https://ebird.org/profile/Nzc4Nzg0NQ',
     description: 'I like tracking sightings, identifying species, and exploring local habitats through birding.',
+    section: 'other',
     tags: ['Observation', 'Nature', 'Tracking']
   }
 ];

--- a/src/hobbiesCards.tsx
+++ b/src/hobbiesCards.tsx
@@ -1,0 +1,19 @@
+import { hobbies } from './hobbies';
+import type { CardItem } from './types';
+
+export const featuredHobbies: CardItem[] = [
+  ...hobbies
+    .filter((hobby) => hobby.section === 'featured')
+    .map((hobby) => ({
+      title: hobby.title,
+      href: `/hobbies/${hobby.slug}`,
+      description: hobby.description,
+      tags: hobby.tags
+    })),
+  {
+    title: 'Other Hobbies',
+    href: '/other_hobbies',
+    description: 'Explore additional hobbies and interests outside of software development.',
+    tags: ['Interests', 'Lifestyle', 'Personal Growth']
+  }
+];

--- a/src/pages/HobbyPage.tsx
+++ b/src/pages/HobbyPage.tsx
@@ -1,0 +1,17 @@
+import type { Hobby } from '../types';
+
+export function HobbyPage({ hobby }: { hobby: Hobby }) {
+  return (
+    <main className="site-main flex-1">
+      <section className="max-w-3xl mx-auto card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card-body space-y-4">
+          <h2 className="text-3xl font-bold text-primary">{hobby.title}</h2>
+          <p className="text-base-content/80">{hobby.description}</p>
+          <div className="pt-2">
+            <a href={hobby.hobbyUrl} className="btn btn-primary" target="_blank" rel="noreferrer">Learn More</a>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,7 +1,7 @@
 import { CardGrid } from '../components/CardGrid';
 import { Section } from '../components/Section';
 import { experienceItems } from '../experience';
-import { hobbies } from '../hobbies';
+import { featuredHobbies } from '../hobbiesCards';
 import { featuredProjects } from '../projectsCards';
 
 export function HomePage() {
@@ -175,7 +175,7 @@ export function HomePage() {
 
       <div className="divider my-1"></div>
 
-      <CardGrid items={hobbies} />
+      <CardGrid items={featuredHobbies} />
     </div>
   </div>
 </Section>

--- a/src/pages/OtherHobbiesPage.tsx
+++ b/src/pages/OtherHobbiesPage.tsx
@@ -1,0 +1,19 @@
+import { CardGrid } from '../components/CardGrid';
+import { hobbies } from '../hobbies';
+import type { CardItem } from '../types';
+
+const items: CardItem[] = hobbies
+  .filter((hobby) => hobby.section === 'other')
+  .map((hobby) => ({
+    title: hobby.title,
+    href: `/hobbies/${hobby.slug}`,
+    description: hobby.description
+  }));
+
+export function OtherHobbiesPage() {
+  return (
+    <main className="site-main flex-1">
+      <CardGrid items={items} grid />
+    </main>
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,13 @@ export type Project = {
   section: 'featured' | 'other';
   tags: string[];
 };
+
+
+export type Hobby = {
+  slug: string;
+  title: string;
+  description: string;
+  hobbyUrl: string;
+  section: 'featured' | 'other';
+  tags: string[];
+};


### PR DESCRIPTION
### Motivation
- Make hobbies behave like projects by supporting internal landing and detail pages instead of direct outbound links from the homepage.
- Provide a consistent UX for featured vs other hobbies so the homepage can surface featured hobby cards and an "Other Hobbies" landing card.
- Enable direct linking to hobby detail pages at `/hobbies/:slug` and a listing at `/other_hobbies` for better navigation and future expandability.

### Description
- Added a `Hobby` type in `src/types.ts` and converted `src/hobbies.tsx` to export structured hobby objects with `slug`, `section`, and `hobbyUrl` fields.
- Introduced `src/hobbiesCards.tsx` which maps featured hobbies into `CardItem` entries and adds an `Other Hobbies` landing card.
- Added hobby pages: detail view `src/pages/HobbyPage.tsx` and listing view `src/pages/OtherHobbiesPage.tsx` to mirror the projects pages.
- Updated routing and selection logic in `src/App.tsx` to handle `hobby` matches and `isOtherHobbies`, and updated `src/pages/HomePage.tsx` to render `featuredHobbies` instead of outbound hobby links.

### Testing
- Ran `npm run build` which invokes the TypeScript/Vite build (`tsc -b && vite build`), and the build failed in this environment due to missing React/Vite/type dependencies rather than the feature changes.
- No other automated tests were run in this environment; new pages and routing are type-checked implicitly by the project build step when dependencies are present.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001334c3ac832b8a2509f30dbb3729)