### PR TITLE
Improve site accessibility and keyboard navigation

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -19,7 +19,7 @@ export function Header({ title, subtitle, links, theme, onThemeChange }: HeaderP
         </div>
         <h1 className="text-4xl font-bold">{title}</h1>
         <p className="mt-2 text-lg">{subtitle}</p>
-        <nav className="flex justify-center space-x-4 mt-4">
+        <nav className="flex justify-center space-x-4 mt-4" aria-label="Primary">
           {links.map((link) => (
             <a key={link.href} href={link.href} className="underline">
               {link.label}

--- a/src/components/ThemeController.tsx
+++ b/src/components/ThemeController.tsx
@@ -9,6 +9,7 @@ export function ThemeController({ theme, onChange }: ThemeControllerProps) {
       <input
         type="checkbox"
         value="dark"
+        aria-label="Toggle dark theme"
         className="toggle theme-controller bg-base-content col-span-2 col-start-1 row-start-1"
         checked={theme === 'dark'}
         onChange={(event) => onChange(event.target.checked ? 'dark' : 'light')}

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -19,6 +19,7 @@ const links = [
 export function Layout({ title, subtitle, children, theme, onThemeChange }: LayoutProps) {
   return (
     <div className="bg-base-200 text-base-content font-sans leading-normal tracking-normal min-h-screen flex flex-col">
+      <a href="#main-content" className="skip-link">Skip to main content</a>
       <Header title={title} subtitle={subtitle} links={links} theme={theme} onThemeChange={onThemeChange} />
       {children}
       <Footer />

--- a/src/pages/HobbyPage.tsx
+++ b/src/pages/HobbyPage.tsx
@@ -2,7 +2,7 @@ import type { Hobby } from '../types';
 
 export function HobbyPage({ hobby }: { hobby: Hobby }) {
   return (
-    <main className="site-main flex-1">
+    <main id="main-content" className="site-main flex-1" tabIndex={-1}>
       <section className="max-w-3xl mx-auto card bg-base-100 border border-base-300 shadow-sm">
         <div className="card-body space-y-4">
           <h2 className="text-3xl font-bold text-primary">{hobby.title}</h2>

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -8,7 +8,7 @@ import { getTagHue } from '../utils/tagColors';
 
 export function HomePage() {
   return (
-    <main className="site-main space-y-16">
+    <main id="main-content" className="site-main space-y-16" tabIndex={-1}>
 <Section title="About Me">
   <div className="card bg-base-200 shadow-md">
     <div className="card-body space-y-4">

--- a/src/pages/OtherHobbiesPage.tsx
+++ b/src/pages/OtherHobbiesPage.tsx
@@ -12,7 +12,7 @@ const items: CardItem[] = hobbies
 
 export function OtherHobbiesPage() {
   return (
-    <main className="site-main flex-1">
+    <main id="main-content" className="site-main flex-1" tabIndex={-1}>
       <CardGrid items={items} grid />
     </main>
   );

--- a/src/pages/OtherProjectsPage.tsx
+++ b/src/pages/OtherProjectsPage.tsx
@@ -12,7 +12,7 @@ const items: CardItem[] = projects
 
 export function OtherProjectsPage() {
   return (
-    <main className="site-main flex-1">
+    <main id="main-content" className="site-main flex-1" tabIndex={-1}>
       <CardGrid items={items} grid />
     </main>
   );

--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -2,7 +2,7 @@ import type { Project } from '../types';
 
 export function ProjectPage({ project }: { project: Project }) {
   return (
-    <main className="site-main flex-1">
+    <main id="main-content" className="site-main flex-1" tabIndex={-1}>
       <section className="max-w-3xl mx-auto card bg-base-100 border border-base-300 shadow-sm">
         <div className="card-body space-y-4">
           <h2 className="text-3xl font-bold text-primary">{project.title}</h2>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -3,6 +3,16 @@
 @tailwind utilities;
 
 @layer components {
+  .skip-link {
+    @apply sr-only focus:not-sr-only focus:absolute focus:top-2 focus:left-2 focus:z-50 focus:px-4 focus:py-2 focus:rounded-md focus:bg-base-100 focus:text-base-content focus:shadow-md;
+  }
+
+  a:focus-visible,
+  button:focus-visible,
+  input:focus-visible {
+    @apply outline outline-2 outline-offset-2 outline-primary;
+  }
+
   .site-header {
     @apply bg-primary text-primary-content p-8 rounded-b-lg shadow-lg;
   }


### PR DESCRIPTION
### Motivation
- Make the site usable for keyboard and assistive technology users by providing a way to skip repetitive navigation and by improving focus visibility and semantic labels.
- Ensure each page has a consistent, programmatically-focusable main content target so keyboard users can jump directly to content.

### Description
- Add a skip link (`<a href="#main-content" className="skip-link">Skip to main content</a>`) in `src/layouts/Layout.tsx` to allow keyboard users to jump to the page body.
- Add `id="main-content"` and `tabIndex={-1}` to page `<main>` elements in `src/pages/HomePage.tsx`, `src/pages/ProjectPage.tsx`, `src/pages/HobbyPage.tsx`, `src/pages/OtherProjectsPage.tsx`, and `src/pages/OtherHobbiesPage.tsx` so the skip link has a reliable focus target.
- Add `aria-label="Primary"` to the header nav in `src/components/Header.tsx` and `aria-label="Toggle dark theme"` to the theme toggle input in `src/components/ThemeController.tsx` to improve screen-reader semantics.
- Add focus-visible styles and skip-link reveal rules in `src/styles/index.css` so keyboard focus is visually apparent and the skip link is hidden by default but visible on focus.

### Testing
- Ran `npm run build` which failed in the current environment because React/Vite type dependencies are not available, and the failure is unrelated to these accessibility markup/CSS changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0013f0a7e4832bb80e8964812023a7)