### PR TITLE
Redesign header with icon-based social links

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,8 @@
 import { ThemeController } from './ThemeController';
+import githubIconDark from '../assets/images/github/GitHub_Invertocat_Black.png';
+import githubIconLight from '../assets/images/github/GitHub_Invertocat_White.png';
+import linkedinIconDark from '../assets/images/github/InBug-Black.png';
+import linkedinIconLight from '../assets/images/github/InBug-White.png';
 
 type NavLink = { label: string; href: string };
 
@@ -11,19 +15,37 @@ type HeaderProps = {
 };
 
 export function Header({ title, subtitle, links, theme, onThemeChange }: HeaderProps) {
+  const socialIconMap = {
+    github: theme === 'dark' ? githubIconLight : githubIconDark,
+    linkedin: theme === 'dark' ? linkedinIconLight : linkedinIconDark
+  } as const;
+
   return (
     <header className="site-header">
-      <div className="container mx-auto text-center py-10 relative">
-        <div className="absolute right-2 top-2">
+      <div className="container mx-auto header-shell relative">
+        <div className="header-theme-control">
           <ThemeController theme={theme} onChange={onThemeChange} />
         </div>
-        <h1 className="text-4xl font-bold">{title}</h1>
-        <p className="mt-2 text-lg">{subtitle}</p>
-        <nav className="flex justify-center space-x-4 mt-4" aria-label="Primary">
+        <h1 className="header-title">{title}</h1>
+        <p className="header-subtitle">{subtitle}</p>
+        <nav className="header-nav" aria-label="Primary">
           {links.map((link) => (
-            <a key={link.href} href={link.href} className="underline">
-              {link.label}
-            </a>
+            /github|linkedin/i.test(link.label) ? (
+              <a
+                key={link.href}
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                className="header-social-link"
+                aria-label={link.label}
+              >
+                <img src={socialIconMap[link.label.toLowerCase() as keyof typeof socialIconMap]} alt="" className="header-social-icon" />
+              </a>
+            ) : (
+              <a key={link.href} href={link.href} className="header-nav-link">
+                {link.label}
+              </a>
+            )
           ))}
         </nav>
       </div>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -14,7 +14,55 @@
   }
 
   .site-header {
-    @apply bg-primary text-primary-content p-8 rounded-b-lg shadow-lg;
+    @apply text-primary-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl;
+    background: linear-gradient(145deg, hsl(var(--p) / 0.94), hsl(var(--s) / 0.9));
+  }
+
+  .header-shell {
+    @apply max-w-6xl text-center px-6 py-8 rounded-3xl border;
+    background-color: hsl(var(--b1) / 0.16);
+    border-color: hsl(var(--b1) / 0.3);
+    backdrop-filter: blur(14px);
+  }
+
+  .header-theme-control {
+    @apply absolute right-6 top-6;
+  }
+
+  .header-title {
+    @apply text-4xl md:text-5xl font-bold tracking-tight;
+  }
+
+  .header-subtitle {
+    @apply mt-4 text-base md:text-lg text-primary-content/90 max-w-3xl mx-auto;
+  }
+
+  .header-nav {
+    @apply mt-8 flex flex-wrap items-center justify-center gap-3;
+  }
+
+  .header-nav-link {
+    @apply px-4 py-2 rounded-full font-medium transition-all duration-200 border border-primary-content/20;
+    background-color: hsl(var(--b1) / 0.08);
+  }
+
+  .header-nav-link:hover {
+    @apply -translate-y-0.5;
+    background-color: hsl(var(--b1) / 0.25);
+  }
+
+  .header-social-link {
+    @apply w-11 h-11 rounded-full flex items-center justify-center transition-all duration-200 border border-primary-content/20;
+    background-color: hsl(var(--b1) / 0.12);
+  }
+
+  .header-social-link:hover {
+    @apply -translate-y-0.5 shadow-md;
+    background-color: hsl(var(--b1) / 0.25);
+  }
+
+  .header-social-icon {
+    @apply w-6 h-6 object-contain;
   }
 
   .site-main {


### PR DESCRIPTION
### Motivation
- Replace text-only GitHub and LinkedIn links with icon images for better visual clarity and brand recognition.
- Restyle the header to a modern, sleek appearance with improved spacing, rounded geometry, and a glassy card feel that adapts to theme.

### Description
- Added imports for existing PNG assets and a theme-aware `socialIconMap` to `src/components/Header.tsx` so social icons switch based on `theme`.
- Updated header rendering to conditionally render GitHub and LinkedIn as icon buttons while preserving other nav items as styled pill links in `src/components/Header.tsx`.
- Introduced new utility classes and layout structure (`.header-shell`, `.header-theme-control`, `.header-title`, `.header-subtitle`, `.header-nav`, `.header-nav-link`, `.header-social-link`, `.header-social-icon`) and replaced the previous header styling with a gradient/backdrop/gussy layout in `src/styles/index.css`.
- Added hover and transition states for nav pills and social icon buttons to improve interactivity and accessibility considerations for focus outlines remain in place.

### Testing
- Attempted `npm run build` in this environment and the TypeScript build failed due to missing project dependencies and type declarations (errors like "Cannot find module 'react'" and missing image module declarations), so the automated build did not succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001609d170832b90ebd4add0c91be3)