### PR TITLE
Add consistent tag coloring and tag exploration pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { OtherProjectsPage } from './pages/OtherProjectsPage';
 import { OtherHobbiesPage } from './pages/OtherHobbiesPage';
 import { ProjectPage } from './pages/ProjectPage';
 import { HobbyPage } from './pages/HobbyPage';
+import { TagPage } from './pages/TagPage';
 import { projects } from './projects';
 import { hobbies } from './hobbies';
 
@@ -24,8 +25,10 @@ function App() {
   const isOtherHobbies = path.includes('other_hobbies');
   const projectMatch = path.match(/^\/projects\/([^/]+)\/?$/);
   const hobbyMatch = path.match(/^\/hobbies\/([^/]+)\/?$/);
+  const tagMatch = path.match(/^\/tags\/([^/]+)\/?$/);
   const project = projectMatch ? projects.find((item) => item.slug === projectMatch[1]) : undefined;
   const hobby = hobbyMatch ? hobbies.find((item) => item.slug === hobbyMatch[1]) : undefined;
+  const tag = tagMatch ? decodeURIComponent(tagMatch[1]) : undefined;
 
   if (project) {
     return (
@@ -47,6 +50,14 @@ function App() {
     return (
       <Layout title="Projects" subtitle="Explore my other projects." theme={theme} onThemeChange={setTheme}>
         <OtherProjectsPage />
+      </Layout>
+    );
+  }
+
+  if (tag) {
+    return (
+      <Layout title="Tags" subtitle="Explore everything related to a specific tag." theme={theme} onThemeChange={setTheme}>
+        <TagPage tag={tag} />
       </Layout>
     );
   }

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -13,9 +13,14 @@ export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: bo
             {item.tags && item.tags.length > 0 && (
               <div className="card-actions pt-2">
                 {item.tags.map((tag) => (
-                  <div key={tag} className="badge tag-badge" style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}>
+                  <a
+                    key={tag}
+                    href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}
+                    className="badge tag-badge hover:opacity-80 transition-opacity"
+                    style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
+                  >
                     {tag}
-                  </div>
+                  </a>
                 ))}
               </div>
             )}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -142,16 +142,16 @@ export function HomePage() {
                 <p key={detail}>{detail}</p>
               ))}
               <div className="card-actions pt-2">
-                {item.tags.map((tag, index) => (
+                {item.tags.map((tag) => (
                   <div
                     key={tag}
                     className={[
                       'badge',
                       'tag-badge'
                     ].join(' ').trim()}
-                    style={{ '--tag-hue': getTagHue(`${item.title}-${index}-${tag}`) } as CSSProperties}
+                    style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
                   >
-                    {tag}
+                    <a href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}>{tag}</a>
                   </div>
                 ))}
               </div>

--- a/src/pages/OtherHobbiesPage.tsx
+++ b/src/pages/OtherHobbiesPage.tsx
@@ -7,7 +7,8 @@ const items: CardItem[] = hobbies
   .map((hobby) => ({
     title: hobby.title,
     href: `/hobbies/${hobby.slug}`,
-    description: hobby.description
+    description: hobby.description,
+    tags: hobby.tags
   }));
 
 export function OtherHobbiesPage() {

--- a/src/pages/OtherProjectsPage.tsx
+++ b/src/pages/OtherProjectsPage.tsx
@@ -7,7 +7,8 @@ const items: CardItem[] = projects
   .map((project) => ({
     title: project.title,
     href: `/projects/${project.slug}`,
-    description: project.description
+    description: project.description,
+    tags: project.tags
   }));
 
 export function OtherProjectsPage() {

--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -1,0 +1,52 @@
+import { projects } from '../projects';
+import { hobbies } from '../hobbies';
+import { experienceItems } from '../experience';
+import type { CardItem } from '../types';
+import { CardGrid } from '../components/CardGrid';
+
+function matchesTag(input: string, tag: string) {
+  return input.trim().toLowerCase() === tag.trim().toLowerCase();
+}
+
+export function TagPage({ tag }: { tag: string }) {
+  const projectLinks: CardItem[] = projects
+    .filter((item) => item.tags.some((itemTag) => matchesTag(itemTag, tag)))
+    .map((item) => ({
+      title: item.title,
+      description: item.description,
+      href: `/projects/${item.slug}`,
+      tags: item.tags
+    }));
+
+  const hobbyLinks: CardItem[] = hobbies
+    .filter((item) => item.tags.some((itemTag) => matchesTag(itemTag, tag)))
+    .map((item) => ({
+      title: item.title,
+      description: item.description,
+      href: `/hobbies/${item.slug}`,
+      tags: item.tags
+    }));
+
+  const experienceLinks: CardItem[] = experienceItems
+    .filter((item) => item.tags.some((itemTag) => matchesTag(itemTag, tag)))
+    .map((item) => ({
+      title: item.title,
+      description: item.meta,
+      href: '/#experience',
+      tags: item.tags
+    }));
+
+  const items = [...projectLinks, ...experienceLinks, ...hobbyLinks];
+
+  return (
+    <main id="main-content" className="site-main flex-1 space-y-4" tabIndex={-1}>
+      <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
+      <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
+      {items.length > 0 ? (
+        <CardGrid items={items} grid />
+      ) : (
+        <div className="alert alert-info">No links found for this tag yet.</div>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
### Motivation
- Ensure tag badges use a single, consistent color mapping across all sections so the same tag keeps the same color between slides and pages.
- Make tags navigable so users can click a tag and see all related links in one place.

### Description
- Use the tag string as the color seed by calling `getTagHue(tag)` for all badges and make card badges into links to `/tags/:tag` in `src/components/CardGrid.tsx`.
- Update the Experience badges in `src/pages/HomePage.tsx` to use `getTagHue(tag)` and make them clickable to the tag page.
- Add a new `TagPage` at `src/pages/TagPage.tsx` that aggregates matching items from `projects`, `hobbies`, and `experienceItems` (case-insensitive match) and displays them via `CardGrid`.
- Add routing/handling for `/tags/:tag` in `src/App.tsx` and include `tags` on Other Projects and Other Hobbies card data so those pages show clickable, consistently coloured badges.

### Testing
- Ran the site build with `npm run build`; the build failed in this environment due to missing project dependencies/type declarations (React/Vite typings), not due to the tag feature changes.
- Manual inspection of changed pages and components was performed locally in the workspace to verify badge color logic and URLs (no automated browser tests were run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00167c7a4c832bbfaed94cd89b3a3f)