### PR TITLE
Fix header text color tokens for light/dark themes

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -14,7 +14,7 @@
   }
 
   .site-header {
-    @apply text-primary-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl;
+    @apply text-base-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl;
     background: linear-gradient(145deg, hsl(var(--p) / 0.94), hsl(var(--s) / 0.9));
   }
 
@@ -34,7 +34,7 @@
   }
 
   .header-subtitle {
-    @apply mt-4 text-base md:text-lg text-primary-content/90 max-w-3xl mx-auto;
+    @apply mt-4 text-base md:text-lg text-base-content/90 max-w-3xl mx-auto;
   }
 
   .header-nav {
@@ -42,7 +42,7 @@
   }
 
   .header-nav-link {
-    @apply px-4 py-2 rounded-full font-medium transition-all duration-200 border border-primary-content/20;
+    @apply px-4 py-2 rounded-full font-medium transition-all duration-200 border border-base-content/20;
     background-color: hsl(var(--b1) / 0.08);
   }
 
@@ -52,7 +52,7 @@
   }
 
   .header-social-link {
-    @apply w-11 h-11 rounded-full flex items-center justify-center transition-all duration-200 border border-primary-content/20;
+    @apply w-11 h-11 rounded-full flex items-center justify-center transition-all duration-200 border border-base-content/20;
     background-color: hsl(var(--b1) / 0.12);
   }
 


### PR DESCRIPTION
### Motivation
- Header text and pill/button borders were using `primary-content` tokens which produced inverted colors between light and dark themes, causing the header to appear with flipped contrast.
- The intent is to make header text and controls follow the active theme's foreground contrast by using the `base-content` tokens.

### Description
- Updated `src/styles/index.css` to replace `text-primary-content` with `text-base-content` for the `.site-header` container.
- Replaced `text-primary-content/90` with `text-base-content/90` for `.header-subtitle`.
- Replaced `border-primary-content/20` with `border-base-content/20` for both `.header-nav-link` and `.header-social-link`.
- This is a CSS-only change to color token references and does not modify JavaScript/TypeScript code.

### Testing
- Ran `npm run build` which failed in this environment due to missing React/Vite type/dependency issues, and the failure is unrelated to this CSS-only token change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00186caff4832b9b47e0b2ac37b17b)