### PR TITLE
Add GitHub and LinkedIn icons to home page header

### DIFF
--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -15,7 +15,9 @@ const homeLinks = [
   { label: 'Technical Skills', href: '#technical-skills' },
   { label: 'Projects', href: '#projects' },
   { label: 'Experience', href: '#experience' },
-  { label: 'Hobbies', href: '#hobbies' }
+  { label: 'Hobbies', href: '#hobbies' },
+  { label: 'GitHub', href: 'https://github.com/axyl-casc' },
+  { label: 'LinkedIn', href: 'https://www.linkedin.com/in/axyl-carefoot-schulz-7b3024200/' }
 ];
 
 const defaultLinks = [


### PR DESCRIPTION
### Motivation
- Ensure the GitHub and LinkedIn social icons appear in the site header on the home page and link to the corresponding profiles. 
- Keep existing theme-aware icon swapping so icons adapt to light/dark mode without extra changes.

### Description
- Added `GitHub` and `LinkedIn` entries to the `homeLinks` array in `src/layouts/Layout.tsx` so the header will render the social icon buttons on `/`.
- No changes to `src/components/Header.tsx` were required because it already maps social labels to theme-aware icon assets and renders them as links.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies/type declarations (React/Vite types), which is unrelated to the header link change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00190d1ce8832b8dccec9edb70f798)