### PR TITLE
Make Core Technologies badges clickable tags

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -187,26 +187,34 @@ export function HomePage() {
       <div className="divider my-0">Core Technologies</div>
 
       <div className="flex flex-wrap gap-2">
-        <div className="badge badge-primary badge-lg">C++</div>
-        <div className="badge badge-primary badge-lg">C</div>
-        <div className="badge badge-primary badge-lg">Python</div>
-
-        <div className="badge badge-secondary badge-lg">React</div>
-        <div className="badge badge-secondary badge-lg">Node.js</div>
-        <div className="badge badge-secondary badge-lg">Electron</div>
-        <div className="badge badge-secondary badge-lg">Tailwind CSS</div>
-
-        <div className="badge badge-accent badge-lg">SQL</div>
-        <div className="badge badge-accent badge-lg">MySQL</div>
-        <div className="badge badge-accent badge-lg">JavaScript</div>
-
-        <div className="badge badge-outline badge-lg">Java</div>
-        <div className="badge badge-outline badge-lg">Git</div>
-        <div className="badge badge-outline badge-lg">Linux</div>
-        <div className="badge badge-outline badge-lg">Assembly</div>
-        <div className="badge badge-outline badge-lg">Matplotlib</div>
-        <div className="badge badge-outline badge-lg">NumPy</div>
-        <div className="badge badge-outline badge-lg">SymPy</div>
+        {[
+          'C++',
+          'C',
+          'Python',
+          'React',
+          'Node.js',
+          'Electron',
+          'Tailwind CSS',
+          'SQL',
+          'MySQL',
+          'JavaScript',
+          'Java',
+          'Git',
+          'Linux',
+          'Assembly',
+          'Matplotlib',
+          'NumPy',
+          'SymPy'
+        ].map((tag) => (
+          <a
+            key={tag}
+            href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}
+            className="badge badge-lg tag-badge hover:opacity-80 transition-opacity"
+            style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
+          >
+            {tag}
+          </a>
+        ))}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Motivation
- Make the "Core Technologies" items behave like the rest of the site's tags so users can click a technology to view its tag page and maintain consistent tag styling.

### Description
- Replaced the static badge elements in `src/pages/HomePage.tsx` with a mapped array that renders anchors linking to `/tags/<tag>` and reuses the `tag-badge` class and `getTagHue(tag)` color behavior to preserve visual styling.

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) and the build failed in this environment due to missing project dependencies/type declarations (for example `react`, `react/jsx-runtime`, and Vite typings), which appears to be a pre-existing setup issue rather than caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001a1839ac832bb3b772a7ad116bf7)