### PR TITLE
Update project tags and hide tags on Other Projects card

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -15,7 +15,7 @@ export const projects: Project[] = [
     description: 'An interactive documentation site built with Quartz, featuring guides, learning modules, and development notes for Infinite Mind Games projects.',
     projectUrl: 'https://infinite-mind-pictures-inc.github.io/Infinite-Mind-Wiki/',
     section: 'featured',
-    tags: ['Quartz', 'Documentation', 'Web Development']
+    tags: ['React', 'JavaScript', 'Java']
   },
   {
     slug: 'beginner-go-ai-game',
@@ -23,7 +23,7 @@ export const projects: Project[] = [
     description: 'A GO playing interface designed to teach beginners how to play the game of GO.',
     projectUrl: 'https://zxnashx.itch.io/beginner-go-game',
     section: 'featured',
-    tags: ['Go / Baduk', 'Game Development', 'Education']
+    tags: ['Python', 'JavaScript', 'NodeJS']
   },
   {
     slug: 'fancy-pants-outfitters-react-demo',
@@ -31,7 +31,7 @@ export const projects: Project[] = [
     description: 'A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.',
     projectUrl: 'https://acare3.github.io/4513_2_website/',
     section: 'featured',
-    tags: ['React', 'Frontend', 'E-commerce']
+    tags: ['TypeScript', 'JavaScript']
   },
   {
     slug: 'defender-remake-atari-st',

--- a/src/projectsCards.tsx
+++ b/src/projectsCards.tsx
@@ -14,6 +14,6 @@ export const featuredProjects: CardItem[] = [
     title: 'Other Projects',
     href: '/other_projects',
     description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.',
-    tags: ['Software Tools', 'Data Visualization', 'Experiments']
+    tags: []
   }
 ];


### PR DESCRIPTION
### Motivation
- Add more accurate technology tags for three featured projects so tag filters and badges reflect their tech stacks.
- Remove visible badges from the "Other Projects" featured card while keeping those projects discoverable via tag search.

### Description
- Updated tags for `infinite-mind-games-wiki-docs` in `src/projects.ts` to `['React', 'JavaScript', 'Java']`.
- Updated tags for `beginner-go-ai-game` in `src/projects.ts` to `['Python', 'JavaScript', 'NodeJS']`.
- Updated tags for `fancy-pants-outfitters-react-demo` in `src/projects.ts` to `['TypeScript', 'JavaScript']`.
- Cleared the visible tags on the homepage "Other Projects" card by setting `tags: []` in `src/projectsCards.tsx`, while leaving the `other` projects' tags in `src/projects.ts` unchanged so they still appear in tag searches.

### Testing
- Ran `npm run build`, which failed due to missing project dependencies/type declarations (TypeScript errors complaining about missing modules like `react`, `react/jsx-runtime`, and `vite`), so the changes were not validated by a successful production build in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001abdbc44832b9bf21b6a7dc30162)