### PR TITLE
Refresh site palette with colorful gradients and glass cards

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -6,7 +6,7 @@ export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: bo
   return (
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
-        <a key={item.href} href={item.href} className="card bg-base-100 border border-base-300 shadow-sm hover:shadow-lg transition-shadow duration-200">
+        <a key={item.href} href={item.href} className="card content-card transition-all duration-200">
           <div className="card-body">
             <h3 className="card-title text-primary">{item.title}</h3>
             <p className="text-base-content/80">{item.description}</p>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -9,7 +9,7 @@ type SectionProps = {
 export function Section({ title, children, id }: SectionProps) {
   return (
     <section id={id}>
-      <h2 className="text-2xl font-semibold mb-4">{title}</h2>
+      <h2 className="section-title">{title}</h2>
       {children}
     </section>
   );

--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -30,7 +30,7 @@ export function Layout({ title, subtitle, children, theme, onThemeChange }: Layo
   const links = window.location.pathname === '/' ? homeLinks : defaultLinks;
 
   return (
-    <div className="bg-base-200 text-base-content font-sans leading-normal tracking-normal min-h-screen flex flex-col">
+    <div className="site-surface text-base-content font-sans leading-normal tracking-normal min-h-screen flex flex-col">
       <a href="#main-content" className="skip-link">Skip to main content</a>
       <Header title={title} subtitle={subtitle} links={links} theme={theme} onThemeChange={onThemeChange} />
       {children}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ export function HomePage() {
   return (
     <main id="main-content" className="site-main space-y-16" tabIndex={-1}>
 <Section id="about-me" title="About Me">
-  <div className="card bg-base-200 shadow-md">
+  <div className="card content-card">
     <div className="card-body space-y-4">
       <p>
         I’m a Computer Science graduate from Mount Royal University with a
@@ -44,7 +44,7 @@ export function HomePage() {
   </div>
 </Section>
 <Section id="technical-skills" title="Technical Skills">
-  <div className="card bg-base-200 shadow-xl border border-base-300">
+  <div className="card content-card">
     <div className="card-body gap-6">
       <div className="space-y-3">
         <p className="text-base-content/80 leading-relaxed max-w-4xl">
@@ -58,7 +58,7 @@ export function HomePage() {
       <div className="divider my-0" />
 
       <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">Programming Languages</h3>
             <p className="text-sm text-base-content/75">
@@ -67,7 +67,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">Software Development</h3>
             <p className="text-sm text-base-content/75">
@@ -78,7 +78,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">
               Web &amp; Application Development
@@ -91,7 +91,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">Backend &amp; Databases</h3>
             <p className="text-sm text-base-content/75">
@@ -102,7 +102,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">Systems Programming</h3>
             <p className="text-sm text-base-content/75">
@@ -113,7 +113,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">
               AI, Algorithms &amp; Computer Science
@@ -126,7 +126,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">
               Data, Visualization &amp; Scientific Computing
@@ -139,7 +139,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">
               Mathematics &amp; Modelling
@@ -152,7 +152,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">UI / UX &amp; Accessibility</h3>
             <p className="text-sm text-base-content/75">
@@ -163,7 +163,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">Tools &amp; Platforms</h3>
             <p className="text-sm text-base-content/75">
@@ -172,7 +172,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card bg-base-100 border border-base-300 shadow-sm md:col-span-2 xl:col-span-2">
+        <div className="card content-card md:col-span-2 xl:col-span-2">
           <div className="card-body">
             <h3 className="card-title text-base">Teaching &amp; Mentoring</h3>
             <p className="text-sm text-base-content/75">
@@ -221,7 +221,7 @@ export function HomePage() {
 </Section>
 
 <Section id="projects" title="Projects">
-  <div className="card bg-base-200 shadow-md">
+  <div className="card content-card">
     <div className="card-body space-y-4">
       <p>
         A selection of projects spanning Go AI tools, interactive learning
@@ -236,7 +236,7 @@ export function HomePage() {
   </div>
 </Section>
 <Section id="experience" title="Experience">
-  <div className="card bg-base-200 shadow-md">
+  <div className="card content-card">
     <div className="card-body space-y-6">
       <p>
         Experience across web development, teaching, technical support, and
@@ -280,7 +280,7 @@ export function HomePage() {
       <hr className="border-neutral-300" />
 
 <Section id="hobbies" title="Hobbies">
-  <div className="card bg-base-200 shadow-md">
+  <div className="card content-card">
     <div className="card-body space-y-4">
       <p>
         Outside of software development, I enjoy hobbies that combine strategy,

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -15,12 +15,12 @@
 
   .site-header {
     @apply text-base-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl;
-    background: linear-gradient(145deg, hsl(var(--p) / 0.94), hsl(var(--s) / 0.9));
+    background: linear-gradient(135deg, hsl(var(--p) / 0.95), hsl(var(--s) / 0.9), hsl(var(--a) / 0.86));
   }
 
   .header-shell {
     @apply max-w-6xl text-center px-6 py-8 rounded-3xl border;
-    background-color: hsl(var(--b1) / 0.16);
+    background-color: hsl(var(--b1) / 0.2);
     border-color: hsl(var(--b1) / 0.3);
     backdrop-filter: blur(14px);
   }
@@ -43,7 +43,7 @@
 
   .header-nav-link {
     @apply px-4 py-2 rounded-full font-medium transition-all duration-200 border border-base-content/20;
-    background-color: hsl(var(--b1) / 0.08);
+    background-color: hsl(var(--b1) / 0.14);
   }
 
   .header-nav-link:hover {
@@ -53,7 +53,7 @@
 
   .header-social-link {
     @apply w-11 h-11 rounded-full flex items-center justify-center transition-all duration-200 border border-base-content/20;
-    background-color: hsl(var(--b1) / 0.12);
+    background-color: hsl(var(--b1) / 0.18);
   }
 
   .header-social-link:hover {
@@ -70,7 +70,36 @@
   }
 
   .site-footer {
-    @apply bg-neutral text-neutral-content p-4 mt-8 text-center;
+    @apply p-4 mt-8 text-center border-t border-base-content/15;
+    background: linear-gradient(140deg, hsl(var(--n) / 0.95), hsl(var(--p) / 0.55));
+    color: hsl(var(--nc));
+  }
+
+  .site-surface {
+    background:
+      radial-gradient(circle at 12% 10%, hsl(var(--p) / 0.2), transparent 40%),
+      radial-gradient(circle at 88% 20%, hsl(var(--a) / 0.22), transparent 42%),
+      radial-gradient(circle at 50% 90%, hsl(var(--s) / 0.22), transparent 45%),
+      linear-gradient(180deg, hsl(var(--b2)), hsl(var(--b1)) 35%, hsl(var(--b2)) 100%);
+  }
+
+  .content-card {
+    @apply border border-base-content/10 shadow-md rounded-2xl;
+    background-color: hsl(var(--b1) / 0.78);
+    backdrop-filter: blur(6px);
+  }
+
+  .content-card:hover {
+    @apply shadow-xl;
+    border-color: hsl(var(--p) / 0.35);
+  }
+
+  .section-title {
+    @apply text-2xl font-semibold mb-4 inline-block;
+    background: linear-gradient(90deg, hsl(var(--p)), hsl(var(--s)), hsl(var(--a)));
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
   }
 
   .tag-badge {


### PR DESCRIPTION
### Motivation
- Make the site feel more colorful and playful while keeping readability by introducing layered gradients and a consistent glass-card visual language.
- Unify card and section styling so content blocks inherit the new palette without changing markup across many pages.

### Description
- Strengthened the header gradient and increased header shell/social background opacity by updating `src/styles/index.css` (`.site-header`, `.header-shell`, `.header-nav-link`, `.header-social-link`).
- Added a full-page layered backdrop via the new `.site-surface` rule and a gradient footer treatment in `src/styles/index.css` to give a vibrant, cohesive background for the whole site.
- Introduced reusable `content-card` (translucent/glass cards with hover emphasis) and `section-title` (gradient text headings) styles in `src/styles/index.css` to provide a playful, colorful aesthetic.
- Switched layout and content components to use the new styles by updating `src/layouts/Layout.tsx` (root element now uses `site-surface`), `src/components/Section.tsx` (uses `section-title`), `src/components/CardGrid.tsx` (cards use `content-card`), and multiple card usages in `src/pages/HomePage.tsx` to use `content-card`.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies/type declarations such as `react` and related TypeScript resolution errors that are unrelated to the styling changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001b394874832bb713ea3d45070998)