### PR TITLE
Make core homepage tags clickable and align project tagging

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -34,11 +34,22 @@ export function HomePage() {
         to both technical and non-technical audiences.
       </p>
 
-      <div className="card-actions">
-        <div className="badge badge-primary">Software Development</div>
-        <div className="badge badge-secondary">Applied AI</div>
-        <div className="badge badge-accent">Game Development</div>
-        <div className="badge badge-outline">Technical Communication</div>
+      <div className="card-actions flex flex-wrap gap-2">
+        {[
+          'Software Development',
+          'Applied AI',
+          'Game Development',
+          'Technical Communication'
+        ].map((tag) => (
+          <a
+            key={tag}
+            href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}
+            className="badge badge-lg tag-badge hover:opacity-80 transition-opacity"
+            style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
+          >
+            {tag}
+          </a>
+        ))}
       </div>
     </div>
   </div>

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -7,7 +7,7 @@ export const projects: Project[] = [
     description: "Created a program to replicate Anscombe's Quartet, emphasizing the importance of visual data analysis.",
     projectUrl: 'https://github.com/axyl-casc/Anscombes_Research?tab=readme-ov-file#anscombes-quartet-research-project',
     section: 'featured',
-    tags: ['Data Analysis', 'Research', 'Python']
+    tags: ['Data Analysis', 'Research', 'Python', 'Software Development']
   },
   {
     slug: 'infinite-mind-games-wiki-docs',
@@ -15,7 +15,7 @@ export const projects: Project[] = [
     description: 'An interactive documentation site built with Quartz, featuring guides, learning modules, and development notes for Infinite Mind Games projects.',
     projectUrl: 'https://infinite-mind-pictures-inc.github.io/Infinite-Mind-Wiki/',
     section: 'featured',
-    tags: ['Quartz', 'Documentation', 'Web Development', 'React', 'JavaScript', 'Java']
+    tags: ['Quartz', 'Documentation', 'Web Development', 'React', 'JavaScript', 'Java', 'Software Development', 'Technical Communication']
   },
   {
     slug: 'beginner-go-ai-game',
@@ -23,7 +23,7 @@ export const projects: Project[] = [
     description: 'A GO playing interface designed to teach beginners how to play the game of GO.',
     projectUrl: 'https://zxnashx.itch.io/beginner-go-game',
     section: 'featured',
-    tags: ['Go / Baduk', 'Game Development', 'Education', 'Python', 'JavaScript', 'NodeJS', 'Electron', 'Tailwind CSS']
+    tags: ['Go / Baduk', 'Game Development', 'Education', 'Python', 'JavaScript', 'NodeJS', 'Electron', 'Tailwind CSS', 'Applied AI', 'Software Development']
   },
   {
     slug: 'fancy-pants-outfitters-react-demo',
@@ -31,7 +31,7 @@ export const projects: Project[] = [
     description: 'A polished React storefront demo featuring curated fashion for trendsetters, workweek looks, and night-out fits. Highlights include in-stock essentials, modern silhouettes, and standout accessories for individuals, partners, and the whole crew.',
     projectUrl: 'https://acare3.github.io/4513_2_website/',
     section: 'featured',
-    tags: ['React', 'Frontend', 'E-commerce', 'TypeScript', 'JavaScript', 'Tailwind CSS']
+    tags: ['React', 'Frontend', 'E-commerce', 'TypeScript', 'JavaScript', 'Tailwind CSS', 'Software Development']
   },
   {
     slug: 'defender-remake-atari-st',
@@ -39,7 +39,7 @@ export const projects: Project[] = [
     description: 'Recreated a classic arcade game using C and assembly, leveraging efficient memory management on limited hardware.',
     projectUrl: 'https://github.com/axyl-casc/DefenderRemake/tree/main?tab=readme-ov-file#atari-st-game---defender',
     section: 'featured',
-    tags: ['C', 'Assembly', 'Game Development']
+    tags: ['C', 'Assembly', 'Game Development', 'Software Development']
   },
   {
     slug: 'linux-shell-development',
@@ -47,7 +47,7 @@ export const projects: Project[] = [
     description: 'Built a custom shell in C, handling concurrent commands and inter-process communication for a streamlined command-line experience.',
     projectUrl: 'https://github.com/axyl-casc/linux-shell?tab=readme-ov-file#linux-shell',
     section: 'featured',
-    tags: ['C', 'Systems Programming', 'Concurrency']
+    tags: ['C', 'Systems Programming', 'Concurrency', 'Software Development']
   },
   {
     slug: 'cpu-scheduler',
@@ -55,7 +55,7 @@ export const projects: Project[] = [
     description: 'Run different CPU scheduling algorithms interactively and view the results afterwards.',
     projectUrl: 'https://axyl-casc.github.io/Scheduler-Designer/',
     section: 'other',
-    tags: ['Algorithms', 'Visualization', 'Education', 'Tailwind CSS'
+    tags: ['Algorithms', 'Visualization', 'Education', 'Tailwind CSS', 'Software Development'
     ]
   },
   {
@@ -64,7 +64,7 @@ export const projects: Project[] = [
     description: 'Effectively calculates possible routes for airplanes to deliver packages with a version made in Javascript and Haskell.',
     projectUrl: 'https://github.com/axyl-casc/AirplaneGraphProject?tab=readme-ov-file#readme',
     section: 'other',
-    tags: ['JavaScript', 'Haskell', 'Graph Algorithms']
+    tags: ['JavaScript', 'Haskell', 'Graph Algorithms', 'Software Development']
   },
   {
     slug: 'daily-training-game',
@@ -72,7 +72,7 @@ export const projects: Project[] = [
     description: 'A daily to-do list app I use for language learning and tracking whatever currently interests me.',
     projectUrl: 'https://axyl-casc.github.io/TrainingGame/',
     section: 'other',
-    tags: ['Productivity', 'Habit Tracking', 'Web App']
+    tags: ['Productivity', 'Habit Tracking', 'Web App', 'Software Development']
   },
   {
     slug: 'goguesser',
@@ -80,7 +80,7 @@ export const projects: Project[] = [
     description: 'Guess the next best move in a Go game.',
     projectUrl: 'https://goguesser.onrender.com/',
     section: 'other',
-    tags: ['Go / Baduk', 'Puzzle', 'Web App', 'NodeJS', 'Tailwind CSS'
+    tags: ['Go / Baduk', 'Puzzle', 'Web App', 'NodeJS', 'Tailwind CSS', 'Game Development', 'Software Development'
     ]
   },
   {
@@ -89,7 +89,7 @@ export const projects: Project[] = [
     description: 'Generate probability distribution tables from custom sets of dice.',
     projectUrl: 'https://axyl-casc.github.io/Dice-Simulator/',
     section: 'other',
-    tags: ['Probability', 'Simulation', 'Visualization']
+    tags: ['Probability', 'Simulation', 'Visualization', 'Software Development']
   },
   {
     slug: 'go-library',
@@ -97,6 +97,6 @@ export const projects: Project[] = [
     description: 'Offline-first bookshelf for Go materials, with search, bookmarks, and resume tracking across PDF/SGF/HTML files.',
     projectUrl: 'https://github.com/axyl-casc/GoLibrary',
     section: 'other',
-    tags: ['Offline-first', 'Search', 'Go / Baduk']
+    tags: ['Offline-first', 'Search', 'Go / Baduk', 'Software Development']
   }
 ];


### PR DESCRIPTION
### Motivation
- Make the four high-level profile badges on the homepage navigable so visitors can click into tag pages for those topics.
- Ensure tag pages return meaningful project results by adding relevant high-level tags to project metadata.

### Description
- Converted the static badges in `src/pages/HomePage.tsx` to clickable tag links that route to `/tags/<tag>` and reuse the existing `tag-badge` style and `getTagHue` hue logic.
- Added `flex flex-wrap gap-2` layout to the homepage tag container for proper wrapping and spacing.
- Updated `src/projects.ts` to add high-level tags (notably `Software Development`, plus `Applied AI`, `Game Development`, and `Technical Communication` where appropriate) across multiple projects so tag filters surface relevant entries.

### Testing
- Ran `npm run build` in this environment and the build failed due to missing React/type dependencies and related tooling issues that are pre-existing in the workspace setup, so the failure is environmental and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001d648698832b9d0da1348903f2cd)