### PR TITLE
Update GitHub Pages workflow for Jekyll auto-build and deploy

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Build and Deploy with Tailwind and GitHub Pages
+name: Deploy Jekyll site to Pages
 
 on:
   push:
@@ -15,47 +15,32 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Build job
   build:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
         with:
-          node-version: 18
+          source: ./
+          destination: ./_site
 
-      - name: Install dependencies
-        run: npm install
-
-      # Build CSS with Tailwind and PostCSS
-      - name: Build Tailwind CSS
-        run: npx tailwindcss -i ./src/styles/input.css -o ./public/styles/tw.css --minify
-        # Copy JavaScript files to public directory
-      - name: Process and Copy JavaScript
-        run: |
-          mkdir -p ./public/js
-          cp -r ./src/js/* ./public/js/
-      # Optional: Run your custom build script if needed
-      - name: Run build script
-        run: npm run build
-
-      # Upload the site files as an artifact
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
-        with:
-          path: ./public
 
-  # Deployment job
   deploy:
     environment:
       name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build
-
     steps:
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
### Motivation
- Replace a custom Node/Tailwind build pipeline with the standard Jekyll + GitHub Pages flow to simplify site publishing. 
- Ensure the repository uses the official Pages actions so GitHub can build and serve the site reliably. 
- Remove unused Node-specific build steps that were not necessary for a Jekyll-hosted site.

### Description
- Rewrote `.github/workflows/jekyll-gh-pages.yml` to use `actions/configure-pages@v5`, `actions/jekyll-build-pages@v1`, `actions/upload-pages-artifact@v3`, and `actions/deploy-pages@v4` for a canonical Pages pipeline. 
- The build job now checks out the repository, configures Pages, builds the site with Jekyll from `./` to `./_site`, and uploads the Pages artifact. 
- Removed Node.js setup, `npm` install, Tailwind/PostCSS steps, manual JS copying, and custom `npm run build` steps. 
- The deploy job now depends on the build job and deploys the uploaded artifact while exposing the deployment URL via the deployment step output.

### Testing
- No automated CI run was executed as part of this change; the workflow file was inspected locally to confirm the new action steps using `nl -ba .github/workflows/jekyll-gh-pages.yml`. 
- A local diff/inspection confirmed the workflow now defines the Jekyll build and Pages deploy jobs and removes the prior Node/Tailwind steps.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001de7682c832bbeab418d5bfb234d)