### PR TITLE
Normalize project/hobby tags and add navigation tags

### DIFF
--- a/src/hobbiesCards.tsx
+++ b/src/hobbiesCards.tsx
@@ -14,6 +14,6 @@ export const featuredHobbies: CardItem[] = [
     title: 'Other Hobbies',
     href: '/other_hobbies',
     description: 'Explore additional hobbies and interests outside of software development.',
-    tags: ['Interests', 'Lifestyle', 'Personal Growth']
+    tags: ['Interests', 'Lifestyle', 'Personal Growth', 'Portfolio']
   }
 ];

--- a/src/projects.ts
+++ b/src/projects.ts
@@ -23,7 +23,7 @@ export const projects: Project[] = [
     description: 'A GO playing interface designed to teach beginners how to play the game of GO.',
     projectUrl: 'https://zxnashx.itch.io/beginner-go-game',
     section: 'featured',
-    tags: ['Go / Baduk', 'Game Development', 'Education', 'Python', 'JavaScript', 'NodeJS', 'Electron', 'Tailwind CSS', 'Applied AI', 'Software Development']
+    tags: ['Baduk / Go', 'Game Development', 'Education', 'Python', 'JavaScript', 'Node.js', 'Electron', 'Tailwind CSS', 'Applied AI', 'Software Development']
   },
   {
     slug: 'fancy-pants-outfitters-react-demo',
@@ -80,7 +80,7 @@ export const projects: Project[] = [
     description: 'Guess the next best move in a Go game.',
     projectUrl: 'https://goguesser.onrender.com/',
     section: 'other',
-    tags: ['Go / Baduk', 'Puzzle', 'Web App', 'NodeJS', 'Tailwind CSS', 'Game Development', 'Software Development'
+    tags: ['Baduk / Go', 'Puzzle', 'Web App', 'Node.js', 'Tailwind CSS', 'Game Development', 'Software Development'
     ]
   },
   {
@@ -97,6 +97,6 @@ export const projects: Project[] = [
     description: 'Offline-first bookshelf for Go materials, with search, bookmarks, and resume tracking across PDF/SGF/HTML files.',
     projectUrl: 'https://github.com/axyl-casc/GoLibrary',
     section: 'other',
-    tags: ['Offline-first', 'Search', 'Go / Baduk', 'Software Development']
+    tags: ['Offline-first', 'Search', 'Baduk / Go', 'Software Development']
   }
 ];

--- a/src/projectsCards.tsx
+++ b/src/projectsCards.tsx
@@ -14,6 +14,6 @@ export const featuredProjects: CardItem[] = [
     title: 'Other Projects',
     href: '/other_projects',
     description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.',
-    tags: []
+    tags: ['Portfolio', 'Navigation']
   }
 ];


### PR DESCRIPTION
### Motivation
- Ensure tag consistency and meaningful navigation tags so tag-based filtering and tag pages behave predictably across projects and hobbies.

### Description
- Replace `Go / Baduk` with `Baduk / Go` and `NodeJS` with `Node.js` in `src/projects.ts` to standardize tag spelling.
- Add `['Portfolio', 'Navigation']` tags to the "Other Projects" navigation card in `src/projectsCards.tsx` so it appears in tag-driven lists.
- Add `Portfolio` to the "Other Hobbies" navigation card in `src/hobbiesCards.tsx` for consistent navigation taxonomy.

### Testing
- Ran `npm run build`, which was attempted and failed due to missing local dependencies/type declarations (e.g., `react`, `vite`); the failure appears unrelated to these tag-only edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001e0e713c832b8cfc7964176b91a8)