### PR TITLE
Remove hover outline artifact from content cards

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -92,6 +92,8 @@
   .content-card:hover {
     @apply shadow-xl;
     border-color: hsl(var(--p) / 0.35);
+    outline: none;
+    box-shadow: var(--tw-shadow);
   }
 
   .section-title {


### PR DESCRIPTION
### Motivation
- Hovering over section cards produced a visible outline/black line artifact around them, so the hover state should explicitly suppress browser outline rendering while keeping the visual elevation.

### Description
- Updated `src/styles/index.css` by modifying the ` .content-card:hover` rule to add `outline: none;` and `box-shadow: var(--tw-shadow);` so the unwanted outline is removed while preserving the Tailwind shadow effect.

### Testing
- Ran `npm run build`, which fails in this environment due to missing project dependencies/types (e.g. `react`, Vite types), and these failures are unrelated to this CSS-only change; no CSS build errors observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001e38aed0832b9521de99a711f45e)