### PR TITLE
Limit hover highlight to clickable cards

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -89,7 +89,7 @@
     backdrop-filter: blur(6px);
   }
 
-  .content-card:hover {
+  a.content-card:hover {
     @apply shadow-xl;
     border-color: hsl(var(--p) / 0.35);
     outline: none;


### PR DESCRIPTION
### Motivation
- Remove the hover highlight from non-clickable content cards (e.g. About Me and main section cards) so only clickable cards show the hover affordance.

### Description
- Change the hover selector in `src/styles/index.css` from `.content-card:hover` to `a.content-card:hover` so only anchor-backed cards receive the highlight, border color, and shadow on hover.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/Vite/type dependencies that are unrelated to this CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001fa7565c832bb59df572ef238398)