### PR TITLE
Fix section title visibility across themes

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -98,10 +98,17 @@
 
   .section-title {
     @apply text-2xl font-semibold mb-4 inline-block;
-    background: linear-gradient(90deg, hsl(var(--p)), hsl(var(--s)), hsl(var(--a)));
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
+    color: hsl(var(--bc));
+  }
+
+  @supports ((-webkit-background-clip: text) or (background-clip: text)) {
+    .section-title {
+      background: linear-gradient(90deg, hsl(var(--p)), hsl(var(--s)), hsl(var(--a)));
+      -webkit-background-clip: text;
+      background-clip: text;
+      -webkit-text-fill-color: transparent;
+      color: transparent;
+    }
   }
 
   .tag-badge {


### PR DESCRIPTION
### Motivation
- Section headings can become unreadable (white-on-white or black-on-black) when gradient text clipping isn't supported or falls back incorrectly, so provide a reliable visible default.

### Description
- Set a readable fallback color for `.section-title` using `color: hsl(var(--bc))` so titles remain visible in both light and dark themes.
- Move the gradient clipping rules into an `@supports` block so transparent/gradient text is only applied when `background-clip: text` (or `-webkit-background-clip: text`) is supported.
- Add `-webkit-text-fill-color: transparent` to ensure consistent clipped-gradient rendering on WebKit-based browsers.
- Changes are in `src/styles/index.css` and only affect the `.section-title` styling.

### Testing
- Ran `npm run build`, which was attempted but failed in this environment due to missing React/Vite/TypeScript dependencies unrelated to this CSS-only change, so the CSS change itself was not the cause of the failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a001fb906b8832b8c30c2508fa29434)