### PR TITLE
Fix section title contrast against page background

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -97,18 +97,7 @@
   }
 
   .section-title {
-    @apply text-2xl font-semibold mb-4 inline-block;
-    color: hsl(var(--bc));
-  }
-
-  @supports ((-webkit-background-clip: text) or (background-clip: text)) {
-    .section-title {
-      background: linear-gradient(90deg, hsl(var(--p)), hsl(var(--s)), hsl(var(--a)));
-      -webkit-background-clip: text;
-      background-clip: text;
-      -webkit-text-fill-color: transparent;
-      color: transparent;
-    }
+    @apply text-2xl font-semibold mb-4 inline-block text-primary;
   }
 
   .tag-badge {


### PR DESCRIPTION
### Motivation
- Section headings could blend into the page surface because the previous gradient `background-clip` + transparent text-fill made titles lose contrast on some theme/background combinations, so they need a consistent readable color.

### Description
- Simplified `.section-title` in `src/styles/index.css` to use `@apply text-2xl font-semibold mb-4 inline-block text-primary` and removed the gradient text-clipping `@supports` block that made the text transparent.

### Testing
- Ran `npm run build`; the build failed in this environment due to missing React/Vite/type dependencies, which is unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002057d2fc832b85bbda76af013a80)