### PR TITLE
Fix Technical Skills grid wrapping for Teaching & Mentoring card

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -196,7 +196,7 @@ export function HomePage() {
           </div>
         </div>
 
-        <div className="card content-card md:col-span-2 xl:col-span-2">
+        <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">Teaching &amp; Mentoring</h3>
             <p className="text-sm text-base-content/75">


### PR DESCRIPTION
### Motivation
- The "Teaching & Mentoring" card was forced onto a new line because it was set to span multiple grid columns at certain breakpoints, which disrupts the skills grid flow.

### Description
- Remove the `md:col-span-2 xl:col-span-2` classes from the `Teaching & Mentoring` card in `src/pages/HomePage.tsx` so it behaves like the other single-cell skill cards.

### Testing
- Ran `npm run -s build`, which failed due to missing project dependencies/type declarations in this environment and not because of the layout change (build failure pre-existed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0020fac93c832bb24ef5b8ace9fec7)