### PR TITLE
Remove tags from Other Projects cards

### DIFF
--- a/src/pages/OtherProjectsPage.tsx
+++ b/src/pages/OtherProjectsPage.tsx
@@ -7,8 +7,7 @@ const items: CardItem[] = projects
   .map((project) => ({
     title: project.title,
     href: `/projects/${project.slug}`,
-    description: project.description,
-    tags: project.tags
+    description: project.description
   }));
 
 export function OtherProjectsPage() {


### PR DESCRIPTION
### Motivation
- The "Other Projects" listing should not show tag badges, so items passed to the card grid must not include tag data.

### Description
- Updated `src/pages/OtherProjectsPage.tsx` to stop passing `tags: project.tags` when mapping `projects` for the `other` section, leaving each `CardItem` with only `title`, `href`, and `description`.

### Testing
- Ran `npm run build`, which failed in this environment due to missing dependencies/type packages (for example `react` and `vite`), so TypeScript compilation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00212d6a60832b97f1e51f45c384cf)