### PR TITLE
Convert home page sections into DaisyUI accordion items

### DIFF
--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -2,15 +2,20 @@ import { ReactNode } from 'react';
 
 type SectionProps = {
   title: string;
+  description: string;
   children: ReactNode;
   id?: string;
 };
 
-export function Section({ title, children, id }: SectionProps) {
+export function Section({ title, description, children, id }: SectionProps) {
   return (
-    <section id={id}>
-      <h2 className="section-title">{title}</h2>
-      {children}
+    <section id={id} className="collapse collapse-arrow bg-base-100 border border-base-300 shadow-sm">
+      <input type="checkbox" defaultChecked />
+      <div className="collapse-title">
+        <h2 className="text-2xl font-semibold text-primary">{title}</h2>
+        <p className="mt-2 text-sm text-base-content/80">{description}</p>
+      </div>
+      <div className="collapse-content pt-1">{children}</div>
     </section>
   );
 }

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -9,7 +9,7 @@ import { getTagHue } from '../utils/tagColors';
 export function HomePage() {
   return (
     <main id="main-content" className="site-main space-y-16" tabIndex={-1}>
-<Section id="about-me" title="About Me">
+<Section id="about-me" title="About Me" description="Background, focus areas, and interests in software and applied AI.">
   <div className="card content-card">
     <div className="card-body space-y-4">
       <p>
@@ -54,7 +54,7 @@ export function HomePage() {
     </div>
   </div>
 </Section>
-<Section id="technical-skills" title="Technical Skills">
+<Section id="technical-skills" title="Technical Skills" description="Core technologies, engineering strengths, and practical development experience.">
   <div className="card content-card">
     <div className="card-body gap-6">
       <div className="space-y-3">
@@ -237,7 +237,7 @@ export function HomePage() {
   </div>
 </Section>
 
-<Section id="projects" title="Projects">
+<Section id="projects" title="Projects" description="Featured work across AI, web development, systems programming, and visualization.">
   <div className="card content-card">
     <div className="card-body space-y-4">
       <p>
@@ -252,7 +252,7 @@ export function HomePage() {
     </div>
   </div>
 </Section>
-<Section id="experience" title="Experience">
+<Section id="experience" title="Experience" description="Professional and teaching experience with a focus on communication and delivery.">
   <div className="card content-card">
     <div className="card-body space-y-6">
       <p>
@@ -296,7 +296,7 @@ export function HomePage() {
 
       <hr className="border-neutral-300" />
 
-<Section id="hobbies" title="Hobbies">
+<Section id="hobbies" title="Hobbies" description="Interests outside software that emphasize strategy, focus, and steady growth.">
   <div className="card content-card">
     <div className="card-body space-y-4">
       <p>


### PR DESCRIPTION
### Motivation
- Make each site section into an interactive accordion so the title and a short description appear in the header and the content expands/collapses when clicked.

### Description
- Reworked the `Section` component to accept a `description` prop and render as a DaisyUI accordion (`collapse collapse-arrow`) with an `<input type="checkbox" defaultChecked />`, a `.collapse-title` containing the `title` and `description`, and a `.collapse-content` wrapping the children.
- Updated all `HomePage` section usages to pass `description` for `About Me`, `Technical Skills`, `Projects`, `Experience`, and `Hobbies` so each accordion header shows title + description.
- Changed files: `src/components/Section.tsx` and `src/pages/HomePage.tsx`.

### Testing
- Ran `npm run build` which runs the TypeScript build and Vite build, and it failed due to missing project dependencies/type declarations (for example `react`, `react-dom`, `react/jsx-runtime`, and Vite typings) in the environment; this failure is unrelated to the accordion change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0021df9228832bad065f6e345d94f5)