### PR TITLE
Enable LAN access for Vite dev server

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,8 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  plugins: [react()]
+  plugins: [react()],
+  server: {
+    host: true
+  }
 });


### PR DESCRIPTION
### Motivation
- Make the local dev server reachable from other devices on the same LAN when running `npm run dev` by binding the server to all network interfaces.

### Description
- Updated `vite.config.ts` to set `server.host` to `true`, so Vite's dev server listens on all interfaces (`host: true`).

### Testing
- Ran `npm run build`, which failed due to existing TypeScript/dependency resolution issues in the environment that are unrelated to the `server.host` change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0024c82a98832bb054d8be8aa25276)