### PR TITLE
Open collapsed section when navigating via header hash links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,17 @@ function App() {
 
       requestAnimationFrame(() => {
         const target = document.getElementById(hash);
-        target?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+
+        if (!target) {
+          return;
+        }
+
+        const collapsibleToggle = target.querySelector<HTMLInputElement>('input[type="checkbox"]');
+        if (collapsibleToggle) {
+          collapsibleToggle.checked = true;
+        }
+
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
       });
     };
 


### PR DESCRIPTION
### Motivation
- Ensure that when a header navigation link (e.g. `#experience`) is followed the target section is opened (not left collapsed) before the page scrolls to it.

### Description
- Updated the `scrollToHashTarget` handler in `src/App.tsx` to locate the element for the URL hash, find an `input[type="checkbox"]` inside the section, set it to checked if present, and then perform the existing smooth scroll.

### Testing
- Ran `npm run build` in this environment which attempted a TypeScript build and Vite build, and it failed due to missing frontend dependencies/type declarations (so the change could not be fully validated by a successful build here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002650aefc832bb1716892e218809f)