### PR TITLE
Theme-specific site background colors (light blue / dark orange)

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -76,11 +76,11 @@
   }
 
   .site-surface {
-    background:
-      radial-gradient(circle at 12% 10%, hsl(var(--p) / 0.2), transparent 40%),
-      radial-gradient(circle at 88% 20%, hsl(var(--a) / 0.22), transparent 42%),
-      radial-gradient(circle at 50% 90%, hsl(var(--s) / 0.22), transparent 45%),
-      linear-gradient(180deg, hsl(var(--b2)), hsl(var(--b1)) 35%, hsl(var(--b2)) 100%);
+    background-color: #dbeafe;
+  }
+
+  :root[data-theme='dark'] .site-surface {
+    background-color: #9a3412;
   }
 
   .content-card {


### PR DESCRIPTION
### Motivation
- Make the main page surface distinct between light and dark themes by using a simple light blue for the light theme and a contrasting dark orange for dark mode.

### Description
- Replace the previous multi-layer gradient on `.site-surface` with `background-color: #dbeafe` for the default (light) theme and add a dark-theme override `:root[data-theme='dark'] .site-surface { background-color: #9a3412; }` in `src/styles/index.css`.

### Testing
- Ran `npm run build` which attempted the TypeScript/Vite build but failed in this environment due to missing project dependencies/types (React/Vite/TypeScript), so no successful build verification was possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00267e97ac832bb28ce9579141b02f)