### PR TITLE
Set header shell background to white

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -20,8 +20,8 @@
 
   .header-shell {
     @apply max-w-6xl text-center px-6 py-8 rounded-3xl border;
-    background-color: hsl(var(--b1) / 0.2);
-    border-color: hsl(var(--b1) / 0.3);
+    background-color: #ffffff;
+    border-color: hsl(var(--b1) / 0.4);
     backdrop-filter: blur(14px);
   }
 


### PR DESCRIPTION
### Motivation

- Make the header container visually white so the header (theme toggle, title, and navigation) appears on a white background as requested.

### Description

- Updated the `.header-shell` rule in `src/styles/index.css` to use `background-color: #ffffff` and changed `border-color` to `hsl(var(--b1) / 0.4)` to preserve border contrast.

### Testing

- No automated tests were run for this visual CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002723a874832b8a88ae16f78e9046)