### PR TITLE
Adjust dark theme surface background to warmer amber

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -79,8 +79,8 @@
     background-color: #dbeafe;
   }
 
-  :root[data-theme='dark'] .site-surface {
-    background-color: #9a3412;
+:root[data-theme='dark'] .site-surface {
+    background-color: #b57a2a;
   }
 
   .content-card {


### PR DESCRIPTION
### Motivation
- Make the dark theme surface background warmer and closer to `#c58930` while keeping it slightly darker.

### Description
- Update `:root[data-theme='dark'] .site-surface` in `src/styles/index.css` from `#9a3412` to `#b57a2a`.

### Testing
- No automated tests were run for this style-only CSS change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0027a405f0832b800156c7c741965b)