### PR TITLE
Fix mobile tag badge overflow when labels wrap

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -104,6 +104,13 @@
     background-color: hsl(var(--tag-hue) 75% 90%);
     border: 1px solid hsl(var(--tag-hue) 60% 55% / 0.45);
     color: hsl(var(--tag-hue) 70% 25%);
+    height: auto;
+    min-height: 1.5rem;
+    white-space: normal;
+    line-height: 1.2;
+    padding-top: 0.25rem;
+    padding-bottom: 0.25rem;
+    text-align: center;
   }
 
   :root[data-theme='dark'] .tag-badge {


### PR DESCRIPTION
### Motivation
- Tag labels on narrow screens could wrap to a second line while the badge retained a fixed height, causing text to overflow outside the pill, so the badge needs to be able to grow vertically when wrapping occurs.

### Description
- Updated `.tag-badge` in `src/styles/index.css` to set `height: auto`, `min-height: 1.5rem`, `white-space: normal`, `line-height: 1.2`, `padding-top: 0.25rem`, `padding-bottom: 0.25rem`, and `text-align: center` so badges can expand for two-line labels and center wrapped text.

### Testing
- Ran `npm run build`, which failed due to missing project dependencies/type declarations (`react`, `vite`, etc.), so the failure is unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0027f99f80832bb9f5a2a03bf88806)