### PR TITLE
Align header palette with section styling

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -14,15 +14,13 @@
   }
 
   .site-header {
-    @apply text-base-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl;
-    background: linear-gradient(135deg, hsl(var(--p) / 0.95), hsl(var(--s) / 0.9), hsl(var(--a) / 0.86));
+    @apply text-base-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl border-b border-base-300;
+    background-color: hsl(var(--b1));
   }
 
   .header-shell {
-    @apply max-w-6xl text-center px-6 py-8 rounded-3xl border;
-    background-color: #ffffff;
-    border-color: hsl(var(--b1) / 0.4);
-    backdrop-filter: blur(14px);
+    @apply max-w-6xl text-center px-6 py-8 rounded-3xl border border-base-300;
+    background-color: hsl(var(--b1));
   }
 
   .header-theme-control {
@@ -30,7 +28,7 @@
   }
 
   .header-title {
-    @apply text-4xl md:text-5xl font-bold tracking-tight;
+    @apply text-4xl md:text-5xl font-bold tracking-tight text-primary;
   }
 
   .header-subtitle {


### PR DESCRIPTION
### Motivation
- Unify header visuals with the rest of the page so header surfaces use the same semantic color tokens as sections.
- Make the main header name/title use the same color as section titles for consistent emphasis across the site.

### Description
- Updated `src/styles/index.css` `.site-header` to remove the gradient and use `background-color: hsl(var(--b1))` with `border-b border-base-300` for parity with section surfaces.
- Updated `.header-shell` in `src/styles/index.css` to use `background-color: hsl(var(--b1))` and `border border-base-300`, removing the custom white overlay and `backdrop-filter` blur.
- Updated `.header-title` to include `text-primary` so the site owner's name matches the section title color.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/Vite dependencies and TypeScript declaration errors, so a successful full build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00281169d0832ba7a9e433ed625bd6)