### PR TITLE
Make header inner shell and tag-result cards use white background

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -2,11 +2,19 @@ import type { CSSProperties } from 'react';
 import type { CardItem } from '../types';
 import { getTagHue } from '../utils/tagColors';
 
-export function CardGrid({ items, grid = false }: { items: CardItem[]; grid?: boolean }) {
+export function CardGrid({
+  items,
+  grid = false,
+  cardClassName = ''
+}: {
+  items: CardItem[];
+  grid?: boolean;
+  cardClassName?: string;
+}) {
   return (
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
-        <a key={item.href} href={item.href} className="card content-card transition-all duration-200">
+        <a key={item.href} href={item.href} className={`card content-card transition-all duration-200 ${cardClassName}`.trim()}>
           <div className="card-body">
             <h3 className="card-title text-primary">{item.title}</h3>
             <p className="text-base-content/80">{item.description}</p>

--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -43,7 +43,7 @@ export function TagPage({ tag }: { tag: string }) {
       <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
       <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
       {items.length > 0 ? (
-        <CardGrid items={items} grid />
+        <CardGrid items={items} grid cardClassName="bg-white" />
       ) : (
         <div className="alert alert-info">No links found for this tag yet.</div>
       )}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -20,7 +20,7 @@
 
   .header-shell {
     @apply max-w-6xl text-center px-6 py-8 rounded-3xl border border-base-300;
-    background-color: hsl(var(--b1));
+    background-color: #ffffff;
   }
 
   .header-theme-control {


### PR DESCRIPTION
### Motivation
- Ensure the header "inner box" renders with a consistent white background so it reads as a distinct card-like element. 
- Ensure project/hobby/experience cards shown after clicking a tag have a white background for better contrast and readability. 

### Description
- Set the `.header-shell` background to solid white in `src/styles/index.css` by changing `background-color` to `#ffffff`.
- Extended `CardGrid` in `src/components/CardGrid.tsx` to accept an optional `cardClassName?: string` prop and append it to the card element's `className` so pages can override card styling.
- Applied `cardClassName="bg-white"` on the tag results page in `src/pages/TagPage.tsx` so all cards rendered there use a white background.

### Testing
- Ran `npm run build` which failed in this environment due to missing React/Vite/TypeScript dependencies and type declarations, and the failure is unrelated to these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0028c71694832ba9b70d6a1e48f4db)