### PR TITLE
Make header background follow section theme in dark/light modes

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -14,13 +14,11 @@
   }
 
   .site-header {
-    @apply text-base-content px-6 pt-8 pb-10 rounded-b-3xl shadow-xl border-b border-base-300;
-    background-color: hsl(var(--b1));
+    @apply text-base-content px-6 pt-8 pb-10 rounded-b-3xl shadow-sm border-b border-base-300 bg-base-100;
   }
 
   .header-shell {
-    @apply max-w-6xl text-center px-6 py-8 rounded-3xl border border-base-300;
-    background-color: #ffffff;
+    @apply max-w-6xl text-center px-6 py-8 rounded-3xl border border-base-300 bg-base-100;
   }
 
   .header-theme-control {


### PR DESCRIPTION
### Motivation
- Ensure the header uses the same theme tokens as section cards so its appearance remains consistent in both light and dark modes.

### Description
- Updated `src/styles/index.css` to make `.site-header` and `.header-shell` use `bg-base-100` and `border-base-300`, removed the hardcoded `background-color: hsl(var(--b1))`/`#ffffff`, and reduced the header shadow to `shadow-sm` to better match section styling.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies and type declarations such as `react`, `react/jsx-runtime`, and `vite`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00296c04c4832b84abac0d034d2ed0)