### PR TITLE
Match tag page project card theme styling

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -43,7 +43,7 @@ export function TagPage({ tag }: { tag: string }) {
       <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
       <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
       {items.length > 0 ? (
-        <CardGrid items={items} grid cardClassName="bg-white" />
+        <CardGrid items={items} grid />
       ) : (
         <div className="alert alert-info">No links found for this tag yet.</div>
       )}


### PR DESCRIPTION
### Motivation
- Ensure project/hobby/experience cards shown on the tag results page follow the same light/dark, theme-aware coloring used by the home page sections.

### Description
- Removed the forced `bg-white` card class on the tag results grid in `src/pages/TagPage.tsx` so the `CardGrid` output inherits the default themed `content-card` styling instead of using a hard-coded white background.

### Testing
- Ran `npm run build` which was executed but failed in this environment due to missing project dependencies and types (e.g. `react`, `react/jsx-runtime`, `vite`), so build errors are unrelated to the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002990b8c8832bae190657769a0c23)