### PR TITLE
Add fixed top-right scroll-to-top button

### DIFF
--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -29,9 +29,16 @@ const defaultLinks = [
 export function Layout({ title, subtitle, children, theme, onThemeChange }: LayoutProps) {
   const links = window.location.pathname === '/' ? homeLinks : defaultLinks;
 
+  const handleScrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
   return (
     <div className="site-surface text-base-content font-sans leading-normal tracking-normal min-h-screen flex flex-col">
       <a href="#main-content" className="skip-link">Skip to main content</a>
+      <button type="button" className="scroll-top-button" onClick={handleScrollToTop} aria-label="Scroll to top">
+        ↑ Top
+      </button>
       <Header title={title} subtitle={subtitle} links={links} theme={theme} onThemeChange={onThemeChange} />
       {children}
       <Footer />

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -65,6 +65,16 @@
     @apply container mx-auto p-8 space-y-12;
   }
 
+  .scroll-top-button {
+    @apply fixed top-4 right-4 z-50 px-4 py-2 rounded-full font-semibold border border-base-content/20 shadow-md transition-all duration-200;
+    background-color: hsl(var(--b1) / 0.9);
+  }
+
+  .scroll-top-button:hover {
+    @apply -translate-y-0.5 shadow-lg;
+    background-color: hsl(var(--b1) / 1);
+  }
+
   .site-footer {
     @apply p-4 mt-8 text-center border-t border-base-content/15;
     background: linear-gradient(140deg, hsl(var(--n) / 0.95), hsl(var(--p) / 0.55));


### PR DESCRIPTION
### Motivation
- Add a persistent, easy-to-find control to let users quickly return to the top of long pages, improving navigation and accessibility.

### Description
- Added a `handleScrollToTop` function and a `<button>` to `src/layouts/Layout.tsx` that calls `window.scrollTo({ top: 0, behavior: 'smooth' })` and includes `aria-label="Scroll to top"` for accessibility.
- Inserted the button before the site header so it appears across pages and placed it with `className="scroll-top-button"` to separate behavior from presentation.
- Added `.scroll-top-button` and hover styles to `src/styles/index.css` using Tailwind `@apply` to fix the control to the top-right corner and match the site visual language.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/Vite/TypeScript dependencies and type packages, so a full production build could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002b80f694832bab783e781cc9ea89)