### PR TITLE
Center core technology tags on home page

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -210,7 +210,7 @@ export function HomePage() {
 
       <div className="divider my-0">Core Technologies</div>
 
-      <div className="flex flex-wrap gap-2">
+      <div className="flex flex-wrap justify-center gap-2">
         {[
           'C++',
           'C',


### PR DESCRIPTION
### Motivation
- Center the tag badges under "Core Technologies" to improve alignment and visual balance in the Technical Skills section.

### Description
- Added `justify-center` to the flex container in `src/pages/HomePage.tsx` that wraps the core technology badges so they are horizontally centered.

### Testing
- Ran `npm run build`, which failed in this environment due to missing React/Vite/TypeScript dependencies and type declarations and is unrelated to this UI alignment change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002c37a390832ba4b99a2d665bf4cf)