### PR TITLE
Remove tags from Other Projects card

### DIFF
--- a/src/projectsCards.tsx
+++ b/src/projectsCards.tsx
@@ -14,6 +14,6 @@ export const featuredProjects: CardItem[] = [
     title: 'Other Projects',
     href: '/other_projects',
     description: 'Explore additional projects, including software tools, data visualizations, and experimental applications.',
-    tags: ['Portfolio', 'Navigation']
+    tags: []
   }
 ];


### PR DESCRIPTION
### Motivation
- Remove the `Portfolio` and `Navigation` tag labels displayed under the `Other Projects` featured card to prevent those badges from showing on the projects list.

### Description
- Updated `src/projectsCards.tsx` to set the `Other Projects` card `tags` to an empty array (`tags: []`).

### Testing
- No automated tests were run for this content/configuration-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002c62f880832ba4b2a0c2973b9bd3)