### PR TITLE
List all hobbies on home page; remove separate “Other Hobbies” card

### DIFF
--- a/src/hobbiesCards.tsx
+++ b/src/hobbiesCards.tsx
@@ -2,18 +2,10 @@ import { hobbies } from './hobbies';
 import type { CardItem } from './types';
 
 export const featuredHobbies: CardItem[] = [
-  ...hobbies
-    .filter((hobby) => hobby.section === 'featured')
-    .map((hobby) => ({
-      title: hobby.title,
-      href: `/hobbies/${hobby.slug}`,
-      description: hobby.description,
-      tags: hobby.tags
-    })),
-  {
-    title: 'Other Hobbies',
-    href: '/other_hobbies',
-    description: 'Explore additional hobbies and interests outside of software development.',
-    tags: ['Interests', 'Lifestyle', 'Personal Growth', 'Portfolio']
-  }
+  ...hobbies.map((hobby) => ({
+    title: hobby.title,
+    href: `/hobbies/${hobby.slug}`,
+    description: hobby.description,
+    tags: hobby.tags
+  }))
 ];


### PR DESCRIPTION
### Motivation
- The UI should not show a separate “Other Hobbies” tab/card and instead surface every hobby directly on the home page.

### Description
- Replaced the filtered/extra-card logic in `src/hobbiesCards.tsx` with a single mapping over `hobbies` that generates a card item for each hobby, removing the standalone `Other Hobbies` entry.

### Testing
- Ran `npm run build` which failed in this environment due to missing project dependencies/type declarations for React/Vite, so no successful build artifacts were produced (failure appears to be an environment/setup issue, not caused by this small change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002c805868832bac826d6b659defce)