### PR TITLE
Make project cards fully clickable and theme-colored

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -15,15 +15,14 @@ export function CardGrid({
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
         <div key={item.href} className={`card content-card transition-all duration-200 ${cardClassName}`.trim()}>
-          <div className="card-body">
-            <h3 className="card-title text-primary">
-              <a href={item.href} className="hover:opacity-80 transition-opacity">
-                {item.title}
-              </a>
+          <div className="card-body relative">
+            <a href={item.href} className="card-link-overlay" aria-label={`Open ${item.title}`} />
+            <h3 className="card-title text-base-content">
+              {item.title}
             </h3>
             <p className="text-base-content/80">{item.description}</p>
             {item.tags && item.tags.length > 0 && (
-              <div className="card-actions pt-2">
+              <div className="card-actions pt-2 relative z-10">
                 {item.tags.map((tag) => (
                   <a
                     key={tag}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -90,16 +90,20 @@
   }
 
   .content-card {
-    @apply border border-base-content/10 shadow-md rounded-2xl;
+    @apply border border-base-content/10 shadow-md rounded-2xl text-base-content;
     background-color: hsl(var(--b1) / 0.78);
     backdrop-filter: blur(6px);
   }
 
-  a.content-card:hover {
+  .content-card:hover {
     @apply shadow-xl;
     border-color: hsl(var(--p) / 0.35);
     outline: none;
     box-shadow: var(--tw-shadow);
+  }
+
+  .card-link-overlay {
+    @apply absolute inset-0 rounded-2xl;
   }
 
   .section-title {


### PR DESCRIPTION
### Motivation
- Ensure project cards on Other Projects and Tag search are fully clickable (not just the title) and that card content uses the theme foreground color so text is readable in light/dark modes.

### Description
- Add a full-card overlay anchor (`.card-link-overlay`) inside each card in `src/components/CardGrid.tsx` so the entire card area is clickable and has `aria-label` for accessibility.
- Preserve interactive tag badges by giving the tag action row a higher stacking context (`relative z-10`) so they remain clickable above the overlay.
- Change card text color usage by applying `text-base-content` to the card container (`.content-card`) and update the title to `text-base-content` so card content follows theme foreground colors.
- Update hover selector to use `.content-card:hover` and add CSS for `.card-link-overlay` in `src/styles/index.css` to maintain rounded overlay and hover behavior.

### Testing
- Ran `npm run build`, which was executed but failed in this environment because required dependencies/type declarations like `react` and `react/jsx-runtime` are not available, so the build did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002d4c55bc832b81af789c544f4b67)