### PR TITLE
Change hobby detail page title to 'Hobbies'

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -73,7 +73,7 @@ function App() {
 
   if (hobby) {
     return (
-      <Layout title="Hobby" subtitle="Hobby details and links." theme={theme} onThemeChange={setTheme}>
+      <Layout title="Hobbies" subtitle="Details and links for hobbies." theme={theme} onThemeChange={setTheme}>
         <HobbyPage hobby={hobby} />
       </Layout>
     );


### PR DESCRIPTION
### Motivation
- The hobby detail route used the singular `Hobby` title which should be pluralized to `Hobbies` for consistency with other pages and headings.

### Description
- Update `src/App.tsx` to render the layout for the hobby detail route with `title="Hobbies"` and `subtitle="Details and links for hobbies."` instead of the previous strings.

### Testing
- No automated tests were run for this small text-only UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002d832d70832b839fb34d2fddcdba)