### PR TITLE
Restrict hover effects to clickable card links

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -14,7 +14,7 @@ export function CardGrid({
   return (
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
-        <div key={item.href} className={`card content-card transition-all duration-200 ${cardClassName}`.trim()}>
+        <div key={item.href} className={`card content-card content-card--interactive transition-all duration-200 ${cardClassName}`.trim()}>
           <div className="card-body relative">
             <a href={item.href} className="card-link-overlay" aria-label={`Open ${item.title}`} />
             <h3 className="card-title text-base-content">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -95,7 +95,7 @@
     backdrop-filter: blur(6px);
   }
 
-  .content-card:hover {
+  .content-card--interactive:hover {
     @apply shadow-xl;
     border-color: hsl(var(--p) / 0.35);
     outline: none;


### PR DESCRIPTION
### Motivation
- Clickable links should show hover affordances while non-interactive content (e.g. About Me and Technical Skills) must not display card hover effects.
- The existing `.content-card:hover` rule applied elevation and shadow to all content cards, producing unwanted hover behavior on non-link sections.

### Description
- Replaced the global hover rule by changing `.content-card:hover` to `.content-card--interactive:hover` in `src/styles/index.css` so the elevation effect only applies to interactive cards.
- Added the `content-card--interactive` class to cards rendered by `CardGrid` in `src/components/CardGrid.tsx` so link-based cards retain the hover affordance.
- The change confines the hover/elevation styling to cards that include the full-card link overlay and leaves tag/link hover styles unchanged.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies/type declarations (`react`, `vite`, and related types), and the build failure is unrelated to this CSS/class change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002e6dd3b4832b953516bd7e743937)