### PR TITLE
Add background styling for tag-filtered project cards

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -43,7 +43,7 @@ export function TagPage({ tag }: { tag: string }) {
       <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
       <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
       {items.length > 0 ? (
-        <CardGrid items={items} grid />
+        <CardGrid items={items} grid cardClassName="tag-results-card" />
       ) : (
         <div className="alert alert-info">No links found for this tag yet.</div>
       )}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -102,6 +102,14 @@
     box-shadow: var(--tw-shadow);
   }
 
+  .tag-results-card {
+    background-color: hsl(var(--p) / 0.14);
+  }
+
+  :root[data-theme='dark'] .tag-results-card {
+    background-color: hsl(var(--p) / 0.22);
+  }
+
   .card-link-overlay {
     @apply absolute inset-0 rounded-2xl;
   }


### PR DESCRIPTION
### Motivation
- Tag result lists should visually differentiate projects by giving each listed project card a subtle background tint when viewing a tag.

### Description
- Pass a dedicated `cardClassName="tag-results-card"` to `CardGrid` on the tag results page (`src/pages/TagPage.tsx`).
- Add `.tag-results-card` CSS rules to `src/styles/index.css` with light and dark theme background colors to tint the cards.

### Testing
- Ran `npm run build`, which failed due to missing environment dependencies/type declarations (missing React/type packages); the failure is unrelated to the styling changes introduced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002f171480832b998fd4aeb15ab9aa)