### PR TITLE
Add tinted backgrounds for cards on tag results pages

### DIFF
--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -5,16 +5,22 @@ import { getTagHue } from '../utils/tagColors';
 export function CardGrid({
   items,
   grid = false,
-  cardClassName = ''
+  cardClassName = '',
+  cardStyle
 }: {
   items: CardItem[];
   grid?: boolean;
   cardClassName?: string;
+  cardStyle?: CSSProperties;
 }) {
   return (
     <div className={grid ? 'grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6' : 'space-y-6'}>
       {items.map((item) => (
-        <div key={item.href} className={`card content-card content-card--interactive transition-all duration-200 ${cardClassName}`.trim()}>
+        <div
+          key={item.href}
+          className={`card content-card content-card--interactive transition-all duration-200 ${cardClassName}`.trim()}
+          style={cardStyle}
+        >
           <div className="card-body relative">
             <a href={item.href} className="card-link-overlay" aria-label={`Open ${item.title}`} />
             <h3 className="card-title text-base-content">

--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -1,8 +1,10 @@
+import type { CSSProperties } from 'react';
 import { projects } from '../projects';
 import { hobbies } from '../hobbies';
 import { experienceItems } from '../experience';
 import type { CardItem } from '../types';
 import { CardGrid } from '../components/CardGrid';
+import { getTagHue } from '../utils/tagColors';
 
 function matchesTag(input: string, tag: string) {
   return input.trim().toLowerCase() === tag.trim().toLowerCase();
@@ -43,7 +45,12 @@ export function TagPage({ tag }: { tag: string }) {
       <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
       <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
       {items.length > 0 ? (
-        <CardGrid items={items} grid cardClassName="tag-results-card" />
+        <CardGrid
+          items={items}
+          grid
+          cardClassName="tag-results-card"
+          cardStyle={{ '--tag-page-hue': getTagHue(tag) } as CSSProperties}
+        />
       ) : (
         <div className="alert alert-info">No links found for this tag yet.</div>
       )}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -103,11 +103,13 @@
   }
 
   .tag-results-card {
-    background-color: hsl(var(--p) / 0.14);
+    background-color: hsl(var(--tag-page-hue, var(--p)) 80% 90% / 0.7);
+    border-color: hsl(var(--tag-page-hue, var(--p)) 55% 52% / 0.45);
   }
 
   :root[data-theme='dark'] .tag-results-card {
-    background-color: hsl(var(--p) / 0.22);
+    background-color: hsl(var(--tag-page-hue, var(--p)) 45% 22% / 0.8);
+    border-color: hsl(var(--tag-page-hue, var(--p)) 70% 62% / 0.4);
   }
 
   .card-link-overlay {


### PR DESCRIPTION
### Motivation
- Tag result pages should make listed projects visually distinct by applying a subtle background tint derived from the selected tag.
- Reuse existing tag-to-hue logic so tag pages have coherent, tag-driven coloring without changing per-tag markup.

### Description
- Add an optional `cardStyle` prop to `CardGrid` and apply it to each rendered card so pages can pass per-card CSS custom properties via inline styles.
- Update `TagPage` to compute a hue with `getTagHue(tag)` and pass it to `CardGrid` as `cardStyle={{ '--tag-page-hue': getTagHue(tag) }}` so all cards on the tag results view share the tag tint.
- Update `.tag-results-card` styles in `src/styles/index.css` to use `--tag-page-hue` for both background and border in light and dark themes so the tint is visible and accessible.

### Testing
- Ran `npm run -s build`, which was executed but the build failed in this environment due to missing project dependencies/type packages (React/Vite/type declarations), so TypeScript/Vite compilation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a002fb6e0bc832b9df1bbee3057376f)