### PR TITLE
Use home/about card colors on tag result listings

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -1,10 +1,8 @@
-import type { CSSProperties } from 'react';
 import { projects } from '../projects';
 import { hobbies } from '../hobbies';
 import { experienceItems } from '../experience';
 import type { CardItem } from '../types';
 import { CardGrid } from '../components/CardGrid';
-import { getTagHue } from '../utils/tagColors';
 
 function matchesTag(input: string, tag: string) {
   return input.trim().toLowerCase() === tag.trim().toLowerCase();
@@ -45,12 +43,7 @@ export function TagPage({ tag }: { tag: string }) {
       <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
       <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
       {items.length > 0 ? (
-        <CardGrid
-          items={items}
-          grid
-          cardClassName="tag-results-card"
-          cardStyle={{ '--tag-page-hue': getTagHue(tag) } as CSSProperties}
-        />
+        <CardGrid items={items} grid />
       ) : (
         <div className="alert alert-info">No links found for this tag yet.</div>
       )}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -102,15 +102,6 @@
     box-shadow: var(--tw-shadow);
   }
 
-  .tag-results-card {
-    background-color: hsl(var(--tag-page-hue, var(--p)) 80% 90% / 0.7);
-    border-color: hsl(var(--tag-page-hue, var(--p)) 55% 52% / 0.45);
-  }
-
-  :root[data-theme='dark'] .tag-results-card {
-    background-color: hsl(var(--tag-page-hue, var(--p)) 45% 22% / 0.8);
-    border-color: hsl(var(--tag-page-hue, var(--p)) 70% 62% / 0.4);
-  }
 
   .card-link-overlay {
     @apply absolute inset-0 rounded-2xl;


### PR DESCRIPTION
### Motivation
- Ensure tag-listing project cards use the same white/light and blackish/dark surface treatment as the home/about sections for visual consistency.

### Description
- Change `src/pages/TagPage.tsx` to render `<CardGrid items={items} grid />` and remove the per-tag `cardClassName`/`cardStyle` usage that relied on `getTagHue`.
- Remove the now-unused `.tag-results-card` light/dark rules from `src/styles/index.css` so tag results inherit the shared `.content-card` styling.

### Testing
- Ran `npm run build` which attempted a TypeScript build and Vite build but failed in this environment due to missing frontend dependencies and type packages (errors reported for missing `react`, `vite`, and related typings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0030b579a4832ba6520441ad3b42eb)