### PR TITLE
Add theme-aware background to TagPage main content

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -39,7 +39,7 @@ export function TagPage({ tag }: { tag: string }) {
   const items = [...projectLinks, ...experienceLinks, ...hobbyLinks];
 
   return (
-    <main id="main-content" className="site-main flex-1 space-y-4" tabIndex={-1}>
+    <main id="main-content" className="site-main flex-1 space-y-4 bg-white dark:bg-black" tabIndex={-1}>
       <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
       <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
       {items.length > 0 ? (


### PR DESCRIPTION
### Motivation
- Ensure the tag page main content uses an appropriate background color for light and dark themes so content remains readable and visually consistent across themes.

### Description
- Updated `src/pages/TagPage.tsx` by adding theme-aware classes to the `<main id="main-content">` element: `bg-white` for light mode and `dark:bg-black` for dark mode.

### Testing
- Ran `npm run lint` and `npm run build`; `npm run lint` failed because no `lint` script is defined in `package.json`, and `npm run build` failed in this environment due to missing dependencies/types (e.g., `react` and related type packages).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0032a1a2f0832ba9fd2c76a10136dd)