### PR TITLE
Style Tag page content with themed card surface

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -40,13 +40,17 @@ export function TagPage({ tag }: { tag: string }) {
 
   return (
     <main id="main-content" className="site-main flex-1 space-y-4" tabIndex={-1}>
-      <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
-      <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
-      {items.length > 0 ? (
-        <CardGrid items={items} grid />
-      ) : (
-        <div className="alert alert-info">No links found for this tag yet.</div>
-      )}
+      <section className="card content-card">
+        <div className="card-body space-y-4">
+          <h2 className="text-2xl font-bold">Tagged: {tag}</h2>
+          <p className="text-base-content/80">Found {items.length} related {items.length === 1 ? 'link' : 'links'}.</p>
+          {items.length > 0 ? (
+            <CardGrid items={items} grid />
+          ) : (
+            <div className="alert alert-info">No links found for this tag yet.</div>
+          )}
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
### Motivation
- Align the Tag page with the Home page by applying the same themed surface treatment so the main content uses the site’s light or dark background styling via existing card styles.

### Description
- Wrap the Tag page main content in a `card content-card` section with an inner `div` using `card-body`, leaving the heading, result count, `CardGrid`, and empty-state alert unchanged functionally in `src/pages/TagPage.tsx`.

### Testing
- No automated tests were run because this is a visual/layout-only change; verify appearance in the browser to confirm light/dark surface behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00334ff8f8832ba11320d9bb4327ed)