### PR TITLE
Add theme-aware background to Tag page main area

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -39,7 +39,7 @@ export function TagPage({ tag }: { tag: string }) {
   const items = [...projectLinks, ...experienceLinks, ...hobbyLinks];
 
   return (
-    <main id="main-content" className="site-main flex-1 space-y-4" tabIndex={-1}>
+    <main id="main-content" className="site-main flex-1 space-y-4 bg-base-100" tabIndex={-1}>
       <section className="card content-card">
         <div className="card-body space-y-4">
           <h2 className="text-2xl font-bold">Tagged: {tag}</h2>


### PR DESCRIPTION
### Motivation
- Ensure the Tag page main content uses the same DaisyUI theme token as the home sections so the background is white in light theme and the dark surface color in dark theme (`bg-base-100`).

### Description
- Updated the `<main>` container in `src/pages/TagPage.tsx` to include the `bg-base-100` class so the main area becomes theme-aware.

### Testing
- Attempted a production build with `npm run build`, which was executed but failed in this environment due to missing project dependencies/type packages (React/Vite type resolution errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0034b62700832b915a4adcff87f2d1)