### PR TITLE
Add Education section to HomePage and add `educationItems` data module

### DIFF
--- a/src/education.tsx
+++ b/src/education.tsx
@@ -1,0 +1,30 @@
+export type EducationItem = {
+  title: string;
+  meta: string;
+  details: string[];
+  tags: string[];
+};
+
+export const educationItems: EducationItem[] = [
+  {
+    title: 'Bachelor of Science – Computer Science',
+    meta: 'Mount Royal University · September 2020 – May 2026 · Calgary, AB',
+    details: [
+      'Cumulative GPA: 3.23 / 4.0.',
+      'Math cognate and Go AI final project.'
+    ],
+    tags: ['Computer Science', 'Mathematics', 'Go AI']
+  },
+  {
+    title: 'Robert Thirsk High School',
+    meta: '2015 – 2018',
+    details: ['Robotics club and science club.'],
+    tags: ['Robotics', 'Science Club']
+  },
+  {
+    title: 'Hockey Alberta - Central Zone Referee Training',
+    meta: '2014 – 2015 · Mount Royal University · Calgary, AB',
+    details: ['Linesman/Referee for Novice and Atom games.'],
+    tags: ['Referee Training', 'Leadership']
+  }
+];

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,6 +2,7 @@ import type { CSSProperties } from 'react';
 import { CardGrid } from '../components/CardGrid';
 import { Section } from '../components/Section';
 import { experienceItems } from '../experience';
+import { educationItems } from '../education';
 import { featuredHobbies } from '../hobbiesCards';
 import { featuredProjects } from '../projectsCards';
 import { getTagHue } from '../utils/tagColors';
@@ -265,6 +266,48 @@ export function HomePage() {
 
       <div className="space-y-6">
         {experienceItems.map((item) => (
+          <div key={item.title} className="card bg-base-100 shadow-sm">
+            <div className="card-body space-y-2">
+              <h3 className="card-title text-base">{item.title}</h3>
+              <p className="text-sm opacity-70">{item.meta}</p>
+              {item.details.map((detail) => (
+                <p key={detail}>{detail}</p>
+              ))}
+              <div className="card-actions pt-2">
+                {item.tags.map((tag) => (
+                  <div
+                    key={tag}
+                    className={[
+                      'badge',
+                      'tag-badge'
+                    ].join(' ').trim()}
+                    style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
+                  >
+                    <a href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}>{tag}</a>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  </div>
+</Section>
+
+
+<Section id="education" title="Education" description="Academic background, training, and foundational learning experiences.">
+  <div className="card content-card">
+    <div className="card-body space-y-6">
+      <p>
+        Education and training experiences that shaped my technical foundation,
+        communication skills, and long-term interest in software development.
+      </p>
+
+      <div className="divider my-1"></div>
+
+      <div className="space-y-6">
+        {educationItems.map((item) => (
           <div key={item.title} className="card bg-base-100 shadow-sm">
             <div className="card-body space-y-2">
               <h3 className="card-title text-base">{item.title}</h3>


### PR DESCRIPTION
### Motivation
- Present academic background on the homepage using the same visual pattern as the existing Experience section.  
- Reuse existing card/tag UI so education entries match the rest of the site and maintain consistent tag/link behavior.

### Description
- Added a new data module `src/education.tsx` that defines `EducationItem` and exports `educationItems` containing three entries (BSc Computer Science at Mount Royal University with GPA and math cognate/Go AI project, Robert Thirsk High School activities, and Hockey Alberta referee training).  
- Updated `src/pages/HomePage.tsx` to import `educationItems` and render a full `Education` section using the same card/list layout as the Experience section.  
- Education tags are rendered with the existing tag color and link behavior via `getTagHue` and tag link generation, and the section is placed between Experience and Hobbies.

### Testing
- Ran `npm run build` to validate the TypeScript build, which failed in the current environment due to missing React/TypeScript dependencies and project-wide type-resolution errors.  
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003680f5a0832baef50651d9852b56)