### PR TITLE
Brighten dark theme orange surface color

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -86,7 +86,7 @@
   }
 
 :root[data-theme='dark'] .site-surface {
-    background-color: #b57a2a;
+    background-color: #d9901f;
   }
 
   .content-card {


### PR DESCRIPTION
### Motivation
- Make the dark theme's orange surface color brighter and more vibrant to improve contrast and visual appeal.

### Description
- Updated the dark-theme `.site-surface` background color in `src/styles/index.css` from `#b57a2a` to `#d9901f`.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies/type declarations unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00374c7414832bb320879081cfa45b)