### PR TITLE
Add Education button to home header navigation

### DIFF
--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -15,6 +15,7 @@ const homeLinks = [
   { label: 'Technical Skills', href: '#technical-skills' },
   { label: 'Projects', href: '#projects' },
   { label: 'Experience', href: '#experience' },
+  { label: 'Education', href: '#education' },
   { label: 'Hobbies', href: '#hobbies' },
   { label: 'GitHub', href: 'https://github.com/axyl-casc' },
   { label: 'LinkedIn', href: 'https://www.linkedin.com/in/axyl-carefoot-schulz-7b3024200/' }


### PR DESCRIPTION
### Motivation
- Provide a direct header button so visitors can jump to the Education section from the home page.

### Description
- Added `{ label: 'Education', href: '#education' }` to the `homeLinks` array in `src/layouts/Layout.tsx` to include an Education button in the home header navigation.

### Testing
- Ran `npm run build`, which failed in this environment because project dependencies and TypeScript/React type declarations are not installed, so the change was not build-verified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0038b48600832b968c0acb94ee5b08)