### PR TITLE
Improve scroll-to-top button readability

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -67,12 +67,13 @@
 
   .scroll-top-button {
     @apply fixed top-4 right-4 z-50 px-4 py-2 rounded-full font-semibold border border-base-content/20 shadow-md transition-all duration-200;
-    background-color: hsl(var(--b1) / 0.9);
+    background-color: hsl(var(--p) / 0.95);
+    color: hsl(var(--pc));
   }
 
   .scroll-top-button:hover {
     @apply -translate-y-0.5 shadow-lg;
-    background-color: hsl(var(--b1) / 1);
+    background-color: hsl(var(--p) / 1);
   }
 
   .site-footer {


### PR DESCRIPTION
### Motivation
- Increase contrast and legibility of the scroll-to-top button so the “↑ Top” label is easier to read against the site background.

### Description
- Updated `src/styles/index.css` to use the theme primary color for the `.scroll-top-button` background, added explicit primary-content text color, and aligned the hover background to the fully opaque primary color for a clearer active state.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies/type declarations (e.g. `react`, `vite`, JSX types), so the failure is unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003903eb80832bb3095bca833bec8e)