### PR TITLE
Adjust scroll-to-top button to match section surfaces

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -66,14 +66,12 @@
   }
 
   .scroll-top-button {
-    @apply fixed top-4 right-4 z-50 px-4 py-2 rounded-full font-semibold border border-base-content/20 shadow-md transition-all duration-200;
-    background-color: hsl(var(--p) / 0.95);
-    color: hsl(var(--pc));
+    @apply fixed top-4 right-4 z-50 px-4 py-2 rounded-full font-semibold border border-base-300 shadow-md transition-all duration-200 bg-base-100 text-base-content;
   }
 
   .scroll-top-button:hover {
     @apply -translate-y-0.5 shadow-lg;
-    background-color: hsl(var(--p) / 1);
+    background-color: hsl(var(--b1) / 0.9);
   }
 
   .site-footer {


### PR DESCRIPTION
### Motivation
- Make the top-right "scroll to top" button share the neutral surface treatment of section/card containers so it appears white in light mode and dark in dark mode and visually aligns with section borders.

### Description
- Updated `.scroll-top-button` in `src/styles/index.css` to apply `bg-base-100`, `text-base-content`, and `border-base-300`, preserved the hover lift (`-translate-y-0.5`/`shadow-lg`) and changed the hover fill to `hsl(var(--b1) / 0.9)` for a subtle surface tint.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies/type declarations (React/Vite typings) and is unrelated to this CSS-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0039910a18832b8becfaf5783f4fbf)