### PR TITLE
Combine Data & Math skills and add AI / LLM card

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -143,11 +143,13 @@ export function HomePage() {
         <div className="card content-card">
           <div className="card-body">
             <h3 className="card-title text-base">
-              Data, Visualization &amp; Scientific Computing
+              Data, Scientific Computing &amp; Mathematical Modelling
             </h3>
             <p className="text-sm text-base-content/75">
               Matplotlib, StatCrunch, NumPy, SymPy, statistical data analysis,
-              research visualization, mathematical modelling, and data-driven
+              research visualization, linear algebra, abstract algebra, discrete
+              mathematics, calculus, mathematical statistics, symbolic logic,
+              network science, and mathematical modelling for data-driven
               application development.
             </p>
           </div>
@@ -155,13 +157,13 @@ export function HomePage() {
 
         <div className="card content-card">
           <div className="card-body">
-            <h3 className="card-title text-base">
-              Mathematics &amp; Modelling
-            </h3>
+            <h3 className="card-title text-base">AI / LLM</h3>
             <p className="text-sm text-base-content/75">
-              Linear algebra, Linear Algebra II, abstract algebra, discrete
-              mathematics, calculus, mathematical statistics, symbolic logic,
-              network science, and mathematical modelling.
+              Daily AI-assisted development workflows focused primarily on OpenAI
+              Codex for planning, implementation, refactoring, and rapid
+              prototyping, with additional experience using Claude and OpenClaw
+              for cross-model validation, prompt comparison, and iterative
+              software delivery.
             </p>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Unify overlapping Data/Visualization and Mathematics cards into a single concise technical-skills entry and introduce an AI / LLM card that documents primary day-to-day usage of OpenAI Codex while noting Claude and OpenClaw for cross-model validation.

### Description
- Modified `src/pages/HomePage.tsx` to replace the separate "Data, Visualization & Scientific Computing" and "Mathematics & Modelling" cards with a single "Data, Scientific Computing & Mathematical Modelling" card and to add a new "AI / LLM" card emphasizing `OpenAI Codex` with mentions of `Claude` and `OpenClaw`.

### Testing
- Ran `npm run build`, which failed due to missing React/Vite/type dependencies and TypeScript resolution errors unrelated to this content-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003a423490832b9bf91d407ec54ef3)