### PR TITLE
Update resume content with legacy education, experience, hobbies, and tools

### DIFF
--- a/src/education.tsx
+++ b/src/education.tsx
@@ -17,8 +17,8 @@ export const educationItems: EducationItem[] = [
   },
   {
     title: 'Robert Thirsk High School',
-    meta: '2015 – 2018',
-    details: ['Robotics club and science club.'],
+    meta: 'Graduated Grade 12 · June 2018 · Calgary, AB',
+    details: ['Completed Computer Science, Robotics, and Mathematics to the 30 level.', 'Participated in robotics club and science club.'],
     tags: ['Robotics', 'Science Club']
   },
   {

--- a/src/experience.tsx
+++ b/src/experience.tsx
@@ -25,10 +25,19 @@ export const experienceItems: ExperienceItem[] = [
   },
   {
     title: 'Mover & IT Support',
-    meta: 'Darwin’s Moving & Deliveries · July 2018 – August 2020 · Calgary, AB',
+    meta: 'Darwin’s Moving & Deliveries Inc. · 2017 – Present · Calgary, AB',
     details: [
+      'Commercial and residential mover handling packing, loading, unloading, and safe transport of client belongings across Calgary.',
       'Provided technical setup and troubleshooting support for client devices, company computers, and hardware/software issues. This role strengthened my practical troubleshooting skills, communication, and ability to solve technical problems in real-world environments.'
     ],
     tags: ['IT Support', 'Troubleshooting', 'Hardware', 'Communication']
+  },
+  {
+    title: 'Hockey Linesman / Referee',
+    meta: 'Bow River Bruins Minor Hockey Association · 2014 – 2015 · Calgary, AB',
+    details: [
+      'Officiated Novice and Atom hockey games as a linesman/referee, applying game rules, conflict resolution, and on-ice communication skills.'
+    ],
+    tags: ['Leadership', 'Officiating', 'Communication']
   }
 ];

--- a/src/hobbies.tsx
+++ b/src/hobbies.tsx
@@ -17,6 +17,23 @@ export const hobbies: Hobby[] = [
     section: 'featured',
     tags: ['Bouldering', 'Problem Solving', 'Fitness']
   },
+
+  {
+    slug: 'sports-history',
+    title: 'Sports & Athletics',
+    hobbyUrl: '',
+    description: 'Long-term participation in Calgary minor hockey (Timbits to Midget, 2005–2016), Saracens Rugby (2014), Track Team (2012–2014), and Robert Thirsk Cross Country (2016–2017).',
+    section: 'other',
+    tags: ['Hockey', 'Rugby', 'Track', 'Cross Country']
+  },
+  {
+    slug: 'reading-travel-robotics',
+    title: 'Reading, Travel & Robotics',
+    hobbyUrl: '',
+    description: 'I enjoy reading, travel, robotics tinkering, programming side projects, and new adventures outdoors.',
+    section: 'other',
+    tags: ['Reading', 'Travel', 'Robotics', 'Adventures']
+  },
   {
     slug: 'bird-watching',
     title: 'Bird Watching',

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -185,7 +185,9 @@ export function HomePage() {
             <p className="text-sm text-base-content/75">
               Docker, Git, PyCharm, Eclipse, Android Studio, Panda3D, Linux,
               Debian, PowerShell, Batch, LaTeX, Microsoft Office, Microsoft
-              Excel, Visual Studio Code, and Windows.
+              Excel, Visual Studio Code, Visual Studio, Source Film Maker,
+              Adobe Photoshop (and other Adobe tools), OBS Studio, Algodoo,
+              and Windows.
             </p>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Preserve and reintroduce legacy resume information (high-school coursework, early work, officiating experience, sports history, and older toolset) so the personal site reflects the full background.
- Ensure hobby and skills sections include items the previous resume listed, such as sports participation and creative/production tools.

### Description
- Updated `src/education.tsx` to add Robert Thirsk High School graduation details and note completion of Computer Science, Robotics, and Mathematics to the 30 level.
- Modified `src/experience.tsx` to show `Darwin’s Moving & Deliveries Inc.` as `2017 – Present`, add a commercial/residential mover responsibility line, and add a `Hockey Linesman / Referee` entry for `Bow River Bruins` (2014–2015).
- Added two hobby entries in `src/hobbies.tsx` (`sports-history` and `reading-travel-robotics`) to capture long-term sports participation and personal interests.
- Expanded the Tools & Platforms list in `src/pages/HomePage.tsx` to include `Visual Studio`, `Source Film Maker`, `Adobe Photoshop` (and other Adobe tools), `OBS Studio`, and `Algodoo`.

### Testing
- Ran the site build with `npm run build`, which invoked TypeScript compilation and `vite build`, but it failed due to missing React/Vite TypeScript dependencies in this environment (type/module resolution errors), so the failure is environmental and not caused by the content updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003b9cbe78832b80f18a02e0102654)