### PR TITLE
Hide project CTA when project URL is missing

### DIFF
--- a/src/pages/ProjectPage.tsx
+++ b/src/pages/ProjectPage.tsx
@@ -1,15 +1,19 @@
 import type { Project } from '../types';
 
 export function ProjectPage({ project }: { project: Project }) {
+  const hasProjectUrl = project.projectUrl.trim().length > 0;
+
   return (
     <main id="main-content" className="site-main flex-1" tabIndex={-1}>
       <section className="max-w-3xl mx-auto card bg-base-100 border border-base-300 shadow-sm">
         <div className="card-body space-y-4">
           <h2 className="text-3xl font-bold text-primary">{project.title}</h2>
           <p className="text-base-content/80">{project.description}</p>
-          <div className="pt-2">
-            <a href={project.projectUrl} className="btn btn-primary" target="_blank" rel="noreferrer">Visit Project</a>
-          </div>
+          {hasProjectUrl ? (
+            <div className="pt-2">
+              <a href={project.projectUrl} className="btn btn-primary" target="_blank" rel="noreferrer">Visit Project</a>
+            </div>
+          ) : null}
         </div>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Prevent showing a "Visit Project" button that doesn't navigate anywhere when a project has no destination URL.

### Description
- In `src/pages/ProjectPage.tsx` compute `hasProjectUrl` using `project.projectUrl.trim().length > 0` and conditionally render the CTA anchor only when `hasProjectUrl` is true.

### Testing
- Ran `npm run build`, which was attempted but failed in this environment due to missing frontend dependencies/types (e.g., `react` and Vite typings), though the change is a minimal conditional render in `ProjectPage`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003e83b5c8832b903fbdcecff2435d)