### PR TITLE
Include education entries in tag search results

### DIFF
--- a/src/pages/TagPage.tsx
+++ b/src/pages/TagPage.tsx
@@ -1,6 +1,7 @@
 import { projects } from '../projects';
 import { hobbies } from '../hobbies';
 import { experienceItems } from '../experience';
+import { educationItems } from '../education';
 import type { CardItem } from '../types';
 import { CardGrid } from '../components/CardGrid';
 
@@ -36,7 +37,16 @@ export function TagPage({ tag }: { tag: string }) {
       tags: item.tags
     }));
 
-  const items = [...projectLinks, ...experienceLinks, ...hobbyLinks];
+  const educationLinks: CardItem[] = educationItems
+    .filter((item) => item.tags.some((itemTag) => matchesTag(itemTag, tag)))
+    .map((item) => ({
+      title: item.title,
+      description: item.meta,
+      href: '/#education',
+      tags: item.tags
+    }));
+
+  const items = [...projectLinks, ...experienceLinks, ...educationLinks, ...hobbyLinks];
 
   return (
     <main id="main-content" className="site-main flex-1 space-y-4 bg-base-100 rounded-2xl" tabIndex={-1}>


### PR DESCRIPTION
### Motivation
- Tags in the Education section (e.g., the Computer Science degree) were not appearing in tag search results, so education entries need to be included as a searchable source.

### Description
- Imported `educationItems` into `src/pages/TagPage.tsx` and added an `educationLinks` mapping to convert matched education items into `CardItem` objects.
- The new `educationLinks` entries set `href` to `/#education` so matches navigate to the Education section on the homepage.
- Updated the combined results array to include `educationLinks` alongside projects, experience, and hobbies in the `items` aggregation.

### Testing
- Ran `npm run build`, which failed in this environment due to missing project dependencies and type declarations (missing `react`, `vite`, and related TypeScript types), so the failure is environmental and unrelated to the tag-matching logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003f60b458832bafb374b12b049c33)