### PR TITLE
Hide hobby CTA when no external URL is set

### DIFF
--- a/src/pages/HobbyPage.tsx
+++ b/src/pages/HobbyPage.tsx
@@ -1,15 +1,19 @@
 import type { Hobby } from '../types';
 
 export function HobbyPage({ hobby }: { hobby: Hobby }) {
+  const hasHobbyUrl = hobby.hobbyUrl.trim().length > 0;
+
   return (
     <main id="main-content" className="site-main flex-1" tabIndex={-1}>
       <section className="max-w-3xl mx-auto card bg-base-100 border border-base-300 shadow-sm">
         <div className="card-body space-y-4">
           <h2 className="text-3xl font-bold text-primary">{hobby.title}</h2>
           <p className="text-base-content/80">{hobby.description}</p>
-          <div className="pt-2">
-            <a href={hobby.hobbyUrl} className="btn btn-primary" target="_blank" rel="noreferrer">Learn More</a>
-          </div>
+          {hasHobbyUrl ? (
+            <div className="pt-2">
+              <a href={hobby.hobbyUrl} className="btn btn-primary" target="_blank" rel="noreferrer">Learn More</a>
+            </div>
+          ) : null}
         </div>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Prevent displaying a non-functional "Learn More" button on hobby detail pages when no external URL is configured by only showing the CTA when a valid `hobby.hobbyUrl` exists.

### Description
- Modify `src/pages/HobbyPage.tsx` to add `const hasHobbyUrl = hobby.hobbyUrl.trim().length > 0` and conditionally render the `Learn More` button only when `hasHobbyUrl` is true.

### Testing
- Ran `npm run build`, which failed due to missing React/type dependencies and TypeScript resolution errors that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a003f736ecc832b90c97529c19005a5)