### PR TITLE
Add portfolio website to Other Projects

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -91,6 +91,15 @@ export const projects: Project[] = [
     section: 'other',
     tags: ['Probability', 'Simulation', 'Visualization', 'Software Development']
   },
+
+  {
+    slug: 'axyl-casc-portfolio-website',
+    title: 'axyl-casc.github.io (Portfolio Website)',
+    description: 'The source repository for this portfolio website, built with React, TypeScript, and Tailwind CSS.',
+    projectUrl: 'https://github.com/axyl-casc/axyl-casc.github.io',
+    section: 'other',
+    tags: ['React', 'TypeScript', 'Tailwind CSS', 'Portfolio', 'Web Development', 'Software Development']
+  },
   {
     slug: 'go-library',
     title: 'Go Library',


### PR DESCRIPTION
### Motivation
- Include the portfolio repository in the site's "Other Projects" list so the website itself appears as a project card on the Other Projects page.

### Description
- Added a new `Project` object to `src/projects.ts` with `slug: 'axyl-casc-portfolio-website'`, `title`, `description`, `projectUrl`, `section: 'other'`, and relevant `tags`.
- Adjusted surrounding punctuation to preserve valid array syntax after insertion.

### Testing
- Ran `npm run build`, which failed due to missing dependencies/type declarations (e.g., `react`) in the environment, and the failure is unrelated to this change.
- No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0040bd03b0832bab38608451c2eaee)