### PR TITLE
Show project tags on other projects cards

### DIFF
--- a/src/pages/OtherProjectsPage.tsx
+++ b/src/pages/OtherProjectsPage.tsx
@@ -7,7 +7,8 @@ const items: CardItem[] = projects
   .map((project) => ({
     title: project.title,
     href: `/projects/${project.slug}`,
-    description: project.description
+    description: project.description,
+    tags: project.tags
   }));
 
 export function OtherProjectsPage() {


### PR DESCRIPTION
### Motivation
- Enable project tags to be visible on `/other_projects` cards so tags render under each project card using the existing `CardGrid` UI.

### Description
- Update `src/pages/OtherProjectsPage.tsx` mapping to include `tags: project.tags` in each `CardItem`, leveraging the `CardGrid` badge rendering.

### Testing
- Ran `npm run build` which failed due to missing React/Vite/TypeScript dependencies and type declarations in the environment, an unrelated pre-existing setup issue rather than a regression from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00426976a0832ba882f129370233c5)