### PR TITLE
Add GitHub Pages workflow to deploy Vite build and clarify README

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,50 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -149,8 +149,10 @@ This repository name suggests GitHub Pages hosting (`axyl-casc.github.io`).
 Typical deployment flow:
 
 1. Build the app with `npm run build`
-2. Publish the `dist/` output to your hosting target (for GitHub Pages, this is often via Actions or a `gh-pages` branch)
+2. Publish the `dist/` output to your hosting target (for GitHub Pages, this repository now includes `.github/workflows/deploy.yml` to automate that on every push to `main`)
 
+> Important: GitHub Pages must publish the compiled `dist/` output, not the raw source files. If Pages serves `src/main.tsx` directly, browsers will reject it with a strict MIME-type module error.
+>
 > If you deploy under a subpath instead of the root domain, ensure Vite `base` and link/path handling are configured appropriately.
 
 ---


### PR DESCRIPTION
### Motivation
- Prevent GitHub Pages from serving raw TS/TSX sources which triggers the browser MIME-type module error when `src/main.tsx` is served instead of the compiled bundle.
- Provide an automated CI step to ensure the compiled `dist/` output is built and published to Pages on pushes to `main`.

### Description
- Added a GitHub Actions workflow at `.github/workflows/deploy.yml` that runs `npm ci`, `npm run build`, uploads `./dist` as a Pages artifact, and deploys it with `actions/deploy-pages`.
- Updated the `README.md` deployment section to explicitly state that GitHub Pages must publish the compiled `dist/` output and to warn about the strict MIME-type module error if source files are served.

### Testing
- Ran `npm ci` in the repository to verify dependencies can be installed, which completed and populated `node_modules`.
- Ran `npm run build` locally to validate the build step used by the workflow, which failed due to existing TypeScript/module resolution errors (for example: `Cannot find module 'react'` and missing `react/jsx-runtime` type declarations), indicating unrelated environment/type issues rather than deployment/workflow regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004360240c832b8fe1dbe1a25eeaf6)