### PR TITLE
Rename Experience to Work Experience

### DIFF
--- a/src/layouts/Layout.tsx
+++ b/src/layouts/Layout.tsx
@@ -14,7 +14,7 @@ const homeLinks = [
   { label: 'About me', href: '#about-me' },
   { label: 'Technical Skills', href: '#technical-skills' },
   { label: 'Projects', href: '#projects' },
-  { label: 'Experience', href: '#experience' },
+  { label: 'Work Experience', href: '#experience' },
   { label: 'Education', href: '#education' },
   { label: 'Hobbies', href: '#hobbies' },
   { label: 'GitHub', href: 'https://github.com/axyl-casc' },

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -261,7 +261,7 @@ export function HomePage() {
     </div>
   </div>
 </Section>
-<Section id="experience" title="Experience" description="Professional and teaching experience with a focus on communication and delivery.">
+<Section id="experience" title="Work Experience" description="Professional and teaching experience with a focus on communication and delivery.">
   <div className="card content-card">
     <div className="card-body space-y-6">
       <p>


### PR DESCRIPTION
### Motivation
- Rename the "Experience" navigation label and homepage section heading to "Work Experience" for clearer wording while keeping existing links intact.

### Description
- Updated `src/layouts/Layout.tsx` and `src/pages/HomePage.tsx` to replace the displayed title/label "Experience" with "Work Experience" and retained the section `id="#experience"`.

### Testing
- Ran `git diff -- src/layouts/Layout.tsx src/pages/HomePage.tsx` and committed the changes with `git commit`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0044fcedfc832b9e5d85a04d007799)