### PR TITLE
fix: prevent Jekyll workflow from overriding Vite Pages deploy

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,8 +1,6 @@
 name: Deploy Jekyll site to Pages
 
 on:
-  push:
-    branches: ["main"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
### Motivation
- Prevent the Jekyll GitHub Actions workflow from auto-deploying source files on every push (which can conflict with the Vite Pages deploy and cause module MIME type errors such as serving `/src/main.tsx` with `application/octet-stream`).

### Description
- Updated `.github/workflows/jekyll-gh-pages.yml` to remove the `push` trigger for `main` so the workflow only runs via `workflow_dispatch`, leaving the rest of the workflow intact.

### Testing
- Verified the workflow trigger change by inspecting the file with `nl -ba .github/workflows/jekyll-gh-pages.yml | sed -n '1,80p'` and committed the update successfully; attempted `npm run build` which failed due to existing TypeScript/dependency issues unrelated to this workflow trigger change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004a2bf8b0832bbb9a35b8fe68ee3b)