### PR TITLE
Fix TypeScript asset and Node type resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^5.4.10"
+    "vite": "^5.4.10",
+    "@types/node": "^22.10.1"
   }
 }

--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,19 @@
+declare module '*.png' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.jpeg' {
+  const src: string;
+  export default src;
+}
+
+declare module '*.JPG' {
+  const src: string;
+  export default src;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -3,7 +3,17 @@
     "composite": true,
     "module": "ESNext",
     "moduleResolution": "Bundler",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "lib": [
+      "ES2020"
+    ],
+    "skipLibCheck": true,
+    "types": [
+      "node"
+    ]
   },
-  "include": ["vite.config.ts", "tailwind.config.ts"]
+  "include": [
+    "vite.config.ts",
+    "tailwind.config.ts"
+  ]
 }


### PR DESCRIPTION
### Motivation
- Resolve TypeScript errors for importing image assets used in React components and for type-checking Vite/Tailwind Node config files.
- Ensure Vite-provided client types are visible to the app so `vite`/`tsc` can type-check modules that rely on Vite ambient types.

### Description
- Added `src/vite-env.d.ts` with `/// <reference types="vite/client" />` to include Vite client typings at compile time.
- Added `src/assets.d.ts` declaring image modules (`*.png`, `*.jpg`, `*.jpeg`, `*.JPG`) so imports like `import foo from '../assets/...png'` resolve to `string` at compile time.
- Updated `tsconfig.node.json` to include `lib: ["ES2020"]`, `skipLibCheck: true`, and `types: ["node"]` to allow Node/Vite config files to type-check against Node typings.
- Added `@types/node` to `devDependencies` in `package.json` to declare Node globals and `node:*` module types for local development and CI.

### Testing
- Ran `npm run build` (which runs `tsc -b && vite build`) as an automated check and it exited with code `1` (build failed).
- The build failure is due to the environment being unable to fetch/install certain packages from the npm registry, which resulted in missing type declarations (notably for `react`/`react-dom` and `@types` packages), so the remaining type errors persist in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004be1b804832bb85fb4cfa706a5b0)