### PR TITLE
fix: sync package.json with package-lock for npm ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^5.4.10",
-    "@types/node": "^22.10.1"
+    "vite": "^5.4.10"
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure `npm ci` can run by bringing the package manifest in sync with the checked-in lockfile to avoid lockfile mismatch failures.

### Description
- Remove `@types/node` from root `devDependencies` in `package.json` because that dependency was not present in `package-lock.json`.

### Testing
- Ran `npm ci` and verified the original out-of-sync lockfile error no longer appears, but the install did not complete in this environment due to registry/network errors (`403 Forbidden` and hanging package fetches).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004d051370832b9f77b2610448fae9)