### PR TITLE
Fix TypeScript build when Node ambient types are unavailable

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,11 +1,12 @@
 import type { Config } from 'tailwindcss';
+import daisyui from 'daisyui';
 
 export default {
   content: ['./index.html', './src/**/*.{ts,tsx}'],
   theme: {
     extend: {}
   },
-  plugins: [require('daisyui')],
+  plugins: [daisyui],
   daisyui: {
     themes: ['light', 'dark']
   }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -7,10 +7,7 @@
     "lib": [
       "ES2020"
     ],
-    "skipLibCheck": true,
-    "types": [
-      "node"
-    ]
+    "skipLibCheck": true
   },
   "include": [
     "vite.config.ts",


### PR DESCRIPTION
### Motivation
- The TypeScript build (`tsc -b`) can fail with `TS2688: Cannot find type definition file for 'node'` when `@types/node` is not installable or available in the environment.
- The Tailwind config used `require('daisyui')`, which can pull Node-style ambient typing expectations into `tsconfig.node.json`-scoped compilation.

### Description
- Removed the explicit `"types": ["node"]` entry from `tsconfig.node.json` so the node ambient type is no longer required during the composite build.
- Converted `tailwind.config.ts` to use an ESM import `import daisyui from 'daisyui'` and pass `daisyui` into the `plugins` array instead of `require(...)`.
- These changes avoid hard dependency on `@types/node` for the repo-level TypeScript build while keeping Tailwind + DaisyUI config as ESM.

### Testing
- Ran `npm install -D @types/node`, which failed in this environment with a `403 Forbidden` from the registry, so the install could not be validated automatically.
- Ran `npm run build` and verified that the original `TS2688` error about missing Node type definitions no longer occurs, but the build still fails due to missing project dependencies/typings (e.g., React/Vite packages), which are unrelated to the Node types fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004f5a4030832bad049e80a0e6302d)