### PR TITLE
fix: sync package.json with lockfile for npm ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5.6.3",
-    "vite": "^5.4.10",
-    "@types/node": "^22.10.1"
+    "vite": "^5.4.10"
   }
 }


### PR DESCRIPTION
### Motivation
- Prevent CI `npm ci` failures caused by a manifest/lockfile mismatch where `@types/node` appeared in `package.json` but not in `package-lock.json`.

### Description
- Removed `@types/node` from `devDependencies` in `package.json` so the manifest matches the committed `package-lock.json`.

### Testing
- Ran `npm ci` and observed the immediate lockfile-sync `EUSAGE` error no longer occurs, but the full install could not complete due to registry/network `403 Forbidden` errors when attempting `npm install`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a004e66c84c832bbf989460fe65e253)