### PR TITLE
Fix GitHub Pages deployment for SPA tag routes

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -1,4 +1,4 @@
-name: Deploy Jekyll site to Pages
+name: Deploy site to Pages
 
 on:
   push:
@@ -21,18 +21,28 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          source: ./
-          destination: ./_site
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Add SPA fallback for GitHub Pages
+        run: cp dist/index.html dist/404.html
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
 
   deploy:
     environment:


### PR DESCRIPTION
### Motivation
- Deep links such as `/tags/python` were returning 404 on GitHub Pages because the repository's workflow built a Jekyll site instead of deploying the Vite/React `dist` output. 
- The site needs an SPA fallback so client-side routes resolve when users navigate directly or refresh deep links.

### Description
- Replaced the Jekyll-based workflow with a Node/Vite pipeline in `.github/workflows/jekyll-gh-pages.yml` by adding Node setup (`actions/setup-node`), `npm ci`, and `npm run build` steps. 
- Added an SPA fallback step that runs `cp dist/index.html dist/404.html` so deep links served by GitHub Pages load the app entry. 
- Updated the Pages artifact upload path to `./dist` and removed the Jekyll build step so the actual Vite build output is deployed.

### Testing
- Ran `npm run build` locally which executes `tsc -b && vite build`, and it failed in this environment with TypeScript/module resolution errors (missing local type modules such as React types), so local build did not complete; CI will install dependencies and run the build as part of the updated workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00526c248c832b9b24f139d9b9d974)