### PR TITLE
Fix GitHub Pages deep-link handling for tag routes

### DIFF
--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Redirecting…</title>
+    <script>
+      (function () {
+        var path = window.location.pathname + window.location.search + window.location.hash;
+        window.location.replace('/?p=' + encodeURIComponent(path));
+      })();
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,19 @@ function App() {
     return stored === 'dark' ? 'dark' : 'light';
   });
 
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const redirectedPath = params.get('p');
+
+    if (!redirectedPath) {
+      return;
+    }
+
+    const decodedPath = decodeURIComponent(redirectedPath);
+    window.history.replaceState(null, '', decodedPath);
+  }, []);
+
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
     localStorage.setItem('theme', theme);


### PR DESCRIPTION
### Motivation
- GitHub Pages returns a 404 for direct SPA deep links such as `/tags/python`, preventing the client-side path-based routing from rendering tag pages.
- Preserve the originally requested path so the single-page app can restore and handle it after the site loads.

### Description
- Add `public/404.html` which captures the current `window.location` and redirects to `/?p=<encoded-path>` so the original path is preserved through GitHub Pages' 404 response.
- Update `src/App.tsx` to add a `useEffect` that reads the `p` query parameter, decodes it, and calls `history.replaceState` to restore the original pathname before normal route matching.

### Testing
- Executed `npm run build` in this environment which attempted the TypeScript build and Vite compilation but failed due to missing dependencies and module/type resolution errors (for example missing `react` and `react/jsx-runtime`), so a full production build could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0054c494a0832ba0dd7bc8a5d11264)