### PR TITLE
Fix tag navigation on GitHub Pages deployment

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,12 +66,17 @@ function App() {
     };
   }, [window.location.pathname]);
 
+
+  const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
   const path = window.location.pathname;
-  const isOtherProjects = path.includes('other_projects');
-  const isOtherHobbies = path.includes('other_hobbies');
-  const projectMatch = path.match(/^\/projects\/([^/]+)\/?$/);
-  const hobbyMatch = path.match(/^\/hobbies\/([^/]+)\/?$/);
-  const tagMatch = path.match(/^\/tags\/([^/]+)\/?$/);
+  const normalizedPath = basePath && path.startsWith(basePath)
+    ? path.slice(basePath.length) || '/'
+    : path;
+  const isOtherProjects = normalizedPath.includes('other_projects');
+  const isOtherHobbies = normalizedPath.includes('other_hobbies');
+  const projectMatch = normalizedPath.match(/^\/projects\/([^/]+)\/?$/);
+  const hobbyMatch = normalizedPath.match(/^\/hobbies\/([^/]+)\/?$/);
+  const tagMatch = normalizedPath.match(/^\/tags\/([^/]+)\/?$/);
   const project = projectMatch ? projects.find((item) => item.slug === projectMatch[1]) : undefined;
   const hobby = hobbyMatch ? hobbies.find((item) => item.slug === hobbyMatch[1]) : undefined;
   const tag = tagMatch ? decodeURIComponent(tagMatch[1]) : undefined;

--- a/src/components/CardGrid.tsx
+++ b/src/components/CardGrid.tsx
@@ -32,7 +32,7 @@ export function CardGrid({
                 {item.tags.map((tag) => (
                   <a
                     key={tag}
-                    href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}
+                    href={`${import.meta.env.BASE_URL}tags/${encodeURIComponent(tag.toLowerCase())}`}
                     className="badge tag-badge hover:opacity-80 transition-opacity"
                     style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
                   >

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -44,7 +44,7 @@ export function HomePage() {
         ].map((tag) => (
           <a
             key={tag}
-            href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}
+            href={`${import.meta.env.BASE_URL}tags/${encodeURIComponent(tag.toLowerCase())}`}
             className="badge badge-lg tag-badge hover:opacity-80 transition-opacity"
             style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
           >
@@ -234,7 +234,7 @@ export function HomePage() {
         ].map((tag) => (
           <a
             key={tag}
-            href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}
+            href={`${import.meta.env.BASE_URL}tags/${encodeURIComponent(tag.toLowerCase())}`}
             className="badge badge-lg tag-badge hover:opacity-80 transition-opacity"
             style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
           >
@@ -291,7 +291,7 @@ export function HomePage() {
                     ].join(' ').trim()}
                     style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
                   >
-                    <a href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}>{tag}</a>
+                    <a href={`${import.meta.env.BASE_URL}tags/${encodeURIComponent(tag.toLowerCase())}`}>{tag}</a>
                   </div>
                 ))}
               </div>
@@ -333,7 +333,7 @@ export function HomePage() {
                     ].join(' ').trim()}
                     style={{ '--tag-hue': getTagHue(tag) } as CSSProperties}
                   >
-                    <a href={`/tags/${encodeURIComponent(tag.toLowerCase())}`}>{tag}</a>
+                    <a href={`${import.meta.env.BASE_URL}tags/${encodeURIComponent(tag.toLowerCase())}`}>{tag}</a>
                   </div>
                 ))}
               </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/axyl-casc.github.io/',
   plugins: [react()],
   server: {
     host: true


### PR DESCRIPTION
### Motivation
- Tag links were generated as root-relative paths and route matching used `window.location.pathname` directly, causing tag clicks to resolve to the site root instead of the deployed `BASE_URL` on GitHub Pages project-site deployments.
- The site needs to work correctly when served from a non-root `base` (e.g. `/axyl-casc.github.io/`).

### Description
- Set Vite `base` to `'/axyl-casc.github.io/'` so built asset and link URLs are generated with the correct deployment base in `vite.config.ts`.
- Updated tag badge `href`s to prefix `import.meta.env.BASE_URL` instead of using root-relative `/tags/...` in `src/components/CardGrid.tsx` and `src/pages/HomePage.tsx` so tag links resolve correctly when deployed.
- Normalized routing in `src/App.tsx` by computing `basePath = import.meta.env.BASE_URL.replace(/\/$/, '')` and stripping it from `window.location.pathname` to produce `normalizedPath` before applying route regexes for `/projects/...`, `/hobbies/...`, and `/tags/...`.
- Changes touch `src/App.tsx`, `src/components/CardGrid.tsx`, `src/pages/HomePage.tsx`, and `vite.config.ts` to ensure link generation and route detection are consistent with the deployment base.

### Testing
- Ran the production build with `npm run build`, which failed in this environment due to missing node dependencies/type declarations (errors: cannot find module `react`, missing types for `ImportMeta.env`, and other dependency type resolution failures), so the build could not be validated here.
- No other automated tests were present or executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0055a6aac4832bb68fc544ab18a8ac)