### PR TITLE
Fix tag pages not rendering after GitHub Pages redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,9 @@ function App() {
   });
 
 
+  const [pathname, setPathname] = useState(() => window.location.pathname);
+
+
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const redirectedPath = params.get('p');
@@ -26,6 +29,7 @@ function App() {
 
     const decodedPath = decodeURIComponent(redirectedPath);
     window.history.replaceState(null, '', decodedPath);
+    setPathname(window.location.pathname);
   }, []);
 
   useEffect(() => {
@@ -64,11 +68,21 @@ function App() {
     return () => {
       window.removeEventListener('hashchange', scrollToHashTarget);
     };
-  }, [window.location.pathname]);
+  }, [pathname]);
+
+
+  useEffect(() => {
+    const updatePathname = () => setPathname(window.location.pathname);
+    window.addEventListener('popstate', updatePathname);
+
+    return () => {
+      window.removeEventListener('popstate', updatePathname);
+    };
+  }, []);
 
 
   const basePath = import.meta.env.BASE_URL.replace(/\/$/, '');
-  const path = window.location.pathname;
+  const path = pathname;
   const normalizedPath = basePath && path.startsWith(basePath)
     ? path.slice(basePath.length) || '/'
     : path;


### PR DESCRIPTION
### Motivation
- Deep links like `/tags/python` on GitHub Pages are redirected through `/?p=...` and the app rewrites history but did not rerender to the restored path. 
- The change ensures route matching runs after the redirect rewrite so tag and other deep routes render immediately.

### Description
- Track the current pathname in React state via `const [pathname, setPathname] = useState(() => window.location.pathname);` in `src/App.tsx`.
- After handling the `?p=` redirect, call `setPathname(window.location.pathname)` to trigger a rerender to the restored path.
- Use the stateful `pathname` for route matching (`const path = pathname;`) and for the hash-scroll effect dependency to ensure consistent reruns.
- Add a `popstate` listener that updates `pathname` so browser history navigation keeps the component route state synchronized.

### Testing
- Ran the project build command `npm run build` in this environment and it failed due to missing project dependencies/type declarations (e.g. `react`, `vite`), so a full build could not be validated here.
- Verified the routing and redirect-handling changes by reviewing the updated `src/App.tsx` logic to ensure `pathname` is updated after `history.replaceState` and on `popstate` events (manual/static validation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0056a6a6d0832b9371f563c510a11f)