### PR TITLE
Fix module MIME error on deep-link routes in GitHub Pages

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,7 +2,7 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
-  base: '/axyl-casc.github.io/',
+  base: '/',
   plugins: [react()],
   server: {
     host: true


### PR DESCRIPTION
### Motivation
- Deep-linked URLs served by GitHub Pages caused asset module requests to resolve to the HTML fallback (`text/html`), which breaks strict MIME checking for `type="module"` scripts.

### Description
- Changed `base` in `vite.config.ts` from `/axyl-casc.github.io/` to `/` so generated asset URLs resolve from the site root and avoid hitting the HTML fallback page for deep links.

### Testing
- Ran `npm run build` successfully and confirmed a production build produced `dist/index.html` and static assets without build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0056e4cf48832b83eda77b979f0f6b)